### PR TITLE
Use MockitoJUnitRunner to create mock instances in tests

### DIFF
--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ClientTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ClientTest.java
@@ -12,7 +12,9 @@ import eu.chargetime.ocpp.model.TestConfirmation;
 import eu.chargetime.ocpp.utilities.TestUtilities;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -47,21 +49,22 @@ import static org.mockito.Mockito.*;
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  */
+
+@RunWith(MockitoJUnitRunner.class)
 public class ClientTest extends TestUtilities {
     private Client client;
     private SessionEvents eventHandler;
-    private static final String IDENTIFIER = "test";
 
     @Mock
-    private Session session = mock(Session.class);
+    private Session session;
     @Mock
-    private Profile profile = mock(Profile.class);
+    private Profile profile;
     @Mock
-    private Feature feature = mock(Feature.class);
+    private Feature feature;
     @Mock
-    private Request request = mock(Request.class);
+    private Request request;
     @Mock
-    ClientEvents events = mock(ClientEvents.class);
+    private ClientEvents events;
 
     @Before
     public void setup() {

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/CommunicatorTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/CommunicatorTest.java
@@ -5,7 +5,9 @@ import eu.chargetime.ocpp.model.Message;
 import eu.chargetime.ocpp.model.Request;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
@@ -35,19 +37,21 @@ import static org.mockito.Mockito.*;
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
+
+@RunWith(MockitoJUnitRunner.class)
 public class CommunicatorTest {
 
     private Communicator communicator;
     private RadioEvents eventHandler;
 
     @Mock
-    private Receiver receiver = mock(Receiver.class);
+    private Receiver receiver;
     @Mock
-    private Request transactionRelatedRequest = mock(Request.class);
+    private Request transactionRelatedRequest;
     @Mock
-    private Request normalRequest = mock(Request.class);
+    private Request normalRequest;
     @Mock
-    private CommunicatorEvents events = mock(CommunicatorEvents.class);
+    private CommunicatorEvents events;
 
     @Before
     public void setup() throws Exception {

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ServerTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ServerTest.java
@@ -8,7 +8,9 @@ import eu.chargetime.ocpp.model.TestConfirmation;
 import eu.chargetime.ocpp.utilities.TestUtilities;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.UUID;
 
@@ -39,6 +41,8 @@ import static org.mockito.Mockito.*;
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
+
+@RunWith(MockitoJUnitRunner.class)
 public class ServerTest extends TestUtilities {
 
     private static final String LOCALHOST = "localhost";
@@ -51,17 +55,17 @@ public class ServerTest extends TestUtilities {
     private UUID sessionIndex;
 
     @Mock
-    private Session session = mock(Session.class);
+    private Session session;
     @Mock
-    private Profile profile = mock(Profile.class);
+    private Profile profile;
     @Mock
-    private Feature feature = mock(Feature.class);
+    private Feature feature;
     @Mock
-    private Listener listener = mock(Listener.class);
+    private Listener listener;
     @Mock
-    private ServerEvents serverEvents = mock(ServerEvents.class);
+    private ServerEvents serverEvents;
     @Mock
-    private Request request = mock(Request.class);
+    private Request request;
 
 
     @Before

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
@@ -7,7 +7,9 @@ import eu.chargetime.ocpp.model.Request;
 import eu.chargetime.ocpp.model.TestRequest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -39,19 +41,21 @@ import static org.mockito.Mockito.*;
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  */
+
+@RunWith(MockitoJUnitRunner.class)
 public class SessionTest {
     private Session session;
 
     private CommunicatorEvents eventHandler;
 
     @Mock
-    Communicator communicator = mock(Communicator.class);
+    private Communicator communicator;
     @Mock
-    Queue queue = mock(Queue.class);
+    private Queue queue;
     @Mock
-    SessionEvents sessionEvents = mock(SessionEvents.class);
+    private SessionEvents sessionEvents;
     @Mock
-    Feature feature = mock(Feature.class);
+    private Feature feature;
 
     @Before
     public void setup() throws Exception {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ClientCoreProfileTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ClientCoreProfileTest.java
@@ -8,7 +8,9 @@ import eu.chargetime.ocpp.model.Request;
 import eu.chargetime.ocpp.model.core.*;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Calendar;
 import java.util.UUID;
@@ -44,6 +46,7 @@ import static org.mockito.Mockito.*;
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class ClientCoreProfileTest
 {
     private static final UUID SESSION_NULL = null;
@@ -51,7 +54,7 @@ public class ClientCoreProfileTest
     private ClientCoreProfile core;
 
     @Mock
-    ClientCoreEventHandler handler = mock(ClientCoreEventHandler.class);
+    ClientCoreEventHandler handler;
 
     @Before
     public void setup() {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ClientRemoteTriggerProfileTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ClientRemoteTriggerProfileTest.java
@@ -7,7 +7,9 @@ import eu.chargetime.ocpp.model.remotetrigger.TriggerMessageConfirmation;
 import eu.chargetime.ocpp.model.remotetrigger.TriggerMessageRequest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.UUID;
 
@@ -41,13 +43,14 @@ import static org.mockito.Mockito.*;
  * SOFTWARE.
  */
 
+@RunWith(MockitoJUnitRunner.class)
 public class ClientRemoteTriggerProfileTest {
 
     private static final UUID SESSION_NULL = null;
     private ClientRemoteTriggerProfile profile;
 
     @Mock
-    ClientRemoteTriggerHandler handler = mock(ClientRemoteTriggerHandler.class);
+    private ClientRemoteTriggerHandler handler;
 
     @Before
     public void setup() {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ClientSmartChargingProfileTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ClientSmartChargingProfileTest.java
@@ -9,7 +9,9 @@ import eu.chargetime.ocpp.model.Request;
 import eu.chargetime.ocpp.model.smartcharging.*;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Calendar;
 import java.util.UUID;
@@ -45,13 +47,14 @@ import static org.mockito.Mockito.*;
  * SOFTWARE.
  */
 
+@RunWith(MockitoJUnitRunner.class)
 public class ClientSmartChargingProfileTest {
 
     private static final UUID SESSION_NULL = null;
     private ClientSmartChargingProfile smartCharging;
 
     @Mock
-    ClientSmartChargingEventHandler handler = mock(ClientSmartChargingEventHandler.class);
+    private ClientSmartChargingEventHandler handler;
 
     @Before
     public void setup() {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ServerCoreProfileTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ServerCoreProfileTest.java
@@ -6,7 +6,9 @@ import eu.chargetime.ocpp.feature.profile.ServerCoreProfile;
 import eu.chargetime.ocpp.model.core.*;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.UUID;
 
@@ -41,12 +43,14 @@ import static org.mockito.Mockito.*;
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
+
+@RunWith(MockitoJUnitRunner.class)
 public class ServerCoreProfileTest {
 
     private ServerCoreProfile core;
 
     @Mock
-    ServerCoreEventHandler handler = mock(ServerCoreEventHandler.class);
+    private ServerCoreEventHandler handler;
 
     @Before
     public void setup() {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ServerRemoteTriggerProfileTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ServerRemoteTriggerProfileTest.java
@@ -8,7 +8,9 @@ import eu.chargetime.ocpp.model.remotetrigger.TriggerMessageRequest;
 import eu.chargetime.ocpp.model.remotetrigger.TriggerMessageRequestType;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -41,12 +43,13 @@ import static org.mockito.Mockito.mock;
  * SOFTWARE.
  */
 
+@RunWith(MockitoJUnitRunner.class)
 public class ServerRemoteTriggerProfileTest {
 
     private ServerRemoteTriggerProfile profile;
 
     @Mock
-    ServerRemoteTriggerHandler handler = mock(ServerRemoteTriggerHandler.class);
+    private ServerRemoteTriggerHandler handler;
 
     @Before
     public void setup() {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ServerSmartChargingProfileTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/feature/profile/test/ServerSmartChargingProfileTest.java
@@ -8,7 +8,9 @@ import eu.chargetime.ocpp.model.core.*;
 import eu.chargetime.ocpp.model.smartcharging.SetChargingProfileRequest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -42,12 +44,13 @@ import static org.mockito.Mockito.mock;
  * SOFTWARE.
  */
 
+@RunWith(MockitoJUnitRunner.class)
 public class ServerSmartChargingProfileTest {
 
     private ServerSmartChargingProfile smartCharging;
 
     @Mock
-    ServerSmartChargingHandler handler = mock(ServerSmartChargingHandler.class);
+    private ServerSmartChargingHandler handler;
 
     @Before
     public void setup() {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/AuthorizeConfirmationTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/AuthorizeConfirmationTest.java
@@ -4,7 +4,9 @@ import eu.chargetime.ocpp.model.core.AuthorizeConfirmation;
 import eu.chargetime.ocpp.model.core.IdTagInfo;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -36,11 +38,12 @@ import static org.mockito.Mockito.*;
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class AuthorizeConfirmationTest {
     AuthorizeConfirmation confirmation;
 
     @Mock
-    IdTagInfo infoTag = mock(IdTagInfo.class);
+    private IdTagInfo infoTag;
 
     @Before
     public void setup() throws Exception {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/MeterValueTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/MeterValueTest.java
@@ -5,6 +5,9 @@ import eu.chargetime.ocpp.model.core.SampledValue;
 import eu.chargetime.ocpp.utilities.TestUtilities;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Calendar;
 
@@ -38,9 +41,11 @@ import static org.mockito.Mockito.*;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class MeterValueTest extends TestUtilities{
     MeterValue meterValue;
-    SampledValue sampledValueMock = mock(SampledValue.class);
+    @Mock
+    private SampledValue sampledValueMock;
 
     @Before
     public void setUp() throws Exception {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/MeterValuesRequestTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/MeterValuesRequestTest.java
@@ -7,6 +7,9 @@ import eu.chargetime.ocpp.utilities.TestUtilities;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -38,9 +41,11 @@ import static org.mockito.Mockito.*;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class MeterValuesRequestTest extends TestUtilities{
     MeterValuesRequest request;
-    MeterValue meterValueMock = mock(MeterValue.class);
+    @Mock
+    private MeterValue meterValueMock;
 
     @Before
     public void setUp() throws Exception {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/JSONCommunicatorTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/JSONCommunicatorTest.java
@@ -9,7 +9,9 @@ import eu.chargetime.ocpp.model.core.RegistrationStatus;
 import eu.chargetime.ocpp.utilities.TestUtilities;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -45,12 +47,13 @@ import static org.mockito.Mockito.*;
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  SOFTWARE.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class JSONCommunicatorTest extends TestUtilities
 {
     private JSONCommunicator communicator;
 
     @Mock
-    Transmitter transmitter = mock(Transmitter.class);
+    private Transmitter transmitter;
 
     @Before
     public void setup() {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/SOAPCommunicatorTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/SOAPCommunicatorTest.java
@@ -9,7 +9,9 @@ import eu.chargetime.ocpp.model.core.RegistrationStatus;
 import eu.chargetime.ocpp.utilities.TestUtilities;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -26,7 +28,6 @@ import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
 
 /*
     ChargeTime.eu - Java-OCA-OCPP
@@ -53,6 +54,7 @@ import static org.mockito.Mockito.mock;
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class SOAPCommunicatorTest extends TestUtilities {
 
     private SOAPCommunicator communicator;
@@ -60,7 +62,7 @@ public class SOAPCommunicatorTest extends TestUtilities {
     private String fromUrl = "http://localhost";
 
     @Mock
-    Transmitter transmitter = mock(Transmitter.class);
+    private Transmitter transmitter;
 
     @Before
     public void setup() {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/TimeoutSessionTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/TimeoutSessionTest.java
@@ -7,7 +7,11 @@ import eu.chargetime.ocpp.model.TestRequest;
 import eu.chargetime.ocpp.utilities.TimeoutTimer;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -37,21 +41,22 @@ import static org.mockito.Mockito.*;
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class TimeoutSessionTest {
 
     private TimeoutSession session;
     private CommunicatorEvents eventHandler;
 
     @Mock
-    Communicator communicator = mock(Communicator.class);
+    private Communicator communicator;
     @Mock
-    Queue queue = mock(Queue.class);
+    private Queue queue;
     @Mock
-    SessionEvents sessionEvents = mock(SessionEvents.class);
+    private SessionEvents sessionEvents;
     @Mock
-    Feature feature = mock(Feature.class);
+    private Feature feature;
     @Mock
-    TimeoutTimer timeoutTimer = mock(TimeoutTimer.class);
+    private TimeoutTimer timeoutTimer;
 
     @Before
     public void setup() throws Exception {


### PR DESCRIPTION
Use MockitoJUnitRunner to create mock instances for "@Mock"-annotated test class fields.