### PR TITLE
added logging based on slf4j

### DIFF
--- a/ocpp-common/pom.xml
+++ b/ocpp-common/pom.xml
@@ -59,6 +59,12 @@
             <version>21.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.10</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Client.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Client.java
@@ -6,6 +6,9 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
 
 import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /*
  ChargeTime.eu - Java-OCA-OCPP
  Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
@@ -44,6 +47,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public abstract class Client extends FeatureHandler
 {
+	private static final Logger logger = LoggerFactory.getLogger(Client.class);
+	
     private Session session;
 
     /**
@@ -115,7 +120,7 @@ public abstract class Client extends FeatureHandler
         try {
             session.close();
         } catch (Exception ex) {
-            ex.printStackTrace();
+            logger.info("session.close() failed", ex);
         }
     }
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
@@ -4,6 +4,9 @@ import eu.chargetime.ocpp.model.*;
 
 import java.util.ArrayDeque;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /*
  ChargeTime.eu - Java-OCA-OCPP
  Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
@@ -41,7 +44,9 @@ import java.util.ArrayDeque;
  * Must be overloaded to implement a specific format.
  */
 public abstract class Communicator {
-    private RetryRunner retryRunner;
+	private static final Logger logger = LoggerFactory.getLogger(Communicator.class);
+
+	private RetryRunner retryRunner;
     protected Radio radio;
     private ArrayDeque<Object> transactionQueue;
     private CommunicatorEvents events;
@@ -158,7 +163,7 @@ public abstract class Communicator {
                 radio.send(call);
             }
         } catch (NotConnectedException ex) {
-            ex.printStackTrace();
+        	logger.warn("sendCall() failed", ex);
             if (request.transactionRelated()) {
                 transactionQueue.add(call);
             } else {
@@ -176,8 +181,8 @@ public abstract class Communicator {
     public void sendCallResult(String uniqueId, String action, Confirmation confirmation) {
         try {
             radio.send(makeCallResult(uniqueId, action, packPayload(confirmation)));
-        } catch (NotConnectedException e) {
-            e.printStackTrace();
+        } catch (NotConnectedException ex) {
+        	logger.warn("sendCallResult() failed", ex);
             events.onError(uniqueId, "Not connected", "The confirmation couldn't be send due to the lack of connection", confirmation);
         }
     }
@@ -193,7 +198,7 @@ public abstract class Communicator {
         try {
             radio.send(makeCallError(uniqueId, action, errorCode, errorDescription));
         } catch (NotConnectedException ex) {
-            ex.printStackTrace();
+        	logger.warn("sendCallError() failed", ex);
             events.onError(uniqueId, "Not connected", "The error couldn't be send due to the lack of connection", errorCode);
         }
     }
@@ -292,7 +297,7 @@ public abstract class Communicator {
                         popRetryMessage();
                 }
             } catch (Exception ex) {
-                ex.printStackTrace();
+            	logger.warn("RetryRunner::run() failed", ex);
             }
         }
     }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Queue.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Queue.java
@@ -5,6 +5,9 @@ import eu.chargetime.ocpp.model.Request;
 import java.util.HashMap;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /*
  ChargeTime.eu - Java-OCA-OCPP
  Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
@@ -37,7 +40,9 @@ import java.util.UUID;
  */
 public class Queue
 {
-    private HashMap<String, Request> requestQueue;
+	private static final Logger logger = LoggerFactory.getLogger(Queue.class);
+
+	private HashMap<String, Request> requestQueue;
 
     public Queue () {
         requestQueue = new HashMap<>();
@@ -59,6 +64,8 @@ public class Queue
      * Restore a {@link Request} using a unique identifier.
      * The identifier can only be used once.
      * If no Request was found, null is returned.
+     * 
+     * FIXME: use optional instead
      *
      * @param ticket    unique identifier returned when {@link Request} was initially stored.
      * @return the stored {@link Request}
@@ -69,7 +76,7 @@ public class Queue
             request = requestQueue.get(ticket);
             requestQueue.remove(ticket);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            logger.warn("restoreRequest({}) failed", ticket, ex);
         }
         return request;
     }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/RequestDispatcher.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/RequestDispatcher.java
@@ -29,9 +29,12 @@ import eu.chargetime.ocpp.model.Request;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 abstract class RequestDispatcher {
 
-    protected SessionEvents eventHandler;
+	protected SessionEvents eventHandler;
 
     public CompletableFuture<Confirmation> handleRequest(Request request)
     {
@@ -40,6 +43,7 @@ abstract class RequestDispatcher {
         return promise;
     }
 
+	// FIXME: fix typo fulfillPromis -> fulfillPromise
     protected abstract void fulfillPromis(CompletableFuture<Confirmation> promise, Request request);
 
     public void setEventHandler(SessionEvents eventHandler) {
@@ -58,6 +62,7 @@ class AsyncRequestDispatcher extends SimpleRequestDispatcher {
 }
 
 class SimpleRequestDispatcher extends RequestDispatcher {
+	private static final Logger logger = LoggerFactory.getLogger(SimpleRequestDispatcher.class);
 
     @Override
     protected void fulfillPromis(CompletableFuture<Confirmation> promise, Request request) {
@@ -65,7 +70,7 @@ class SimpleRequestDispatcher extends RequestDispatcher {
             Confirmation conf = eventHandler.handleRequest(request);
             promise.complete(conf);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            logger.warn("fulfillPromis() failed", ex);
             promise.completeExceptionally(ex);
         }
     }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/utilities/ModelUtil.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/utilities/ModelUtil.java
@@ -39,10 +39,10 @@ public abstract class ModelUtil {
      * @param hayStack list of value that we search in.
      * @return true if value was found in list.
      */
-    public static boolean isAmong(Object needle, Object... hayStack) {
+    public static boolean isAmong(String needle, String... hayStack) {
         boolean found = false;
         if (hayStack != null) {
-            for (Object straw : hayStack) {
+            for (String straw : hayStack) {
                 if (found = isNullOrEqual(straw, needle)) {
                     break;
                 }

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/utilities/test/ModelUtilTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/utilities/test/ModelUtilTest.java
@@ -101,16 +101,18 @@ public class ModelUtilTest {
     @Test
     public void isAmong_needleAndHaystackIsNull_returnsFalse() {
         // When
-        boolean found = ModelUtil.isAmong(null, null);
+        boolean found = ModelUtil.isAmong((String)null, (String)null);
 
         // Then
-        assertThat(found, is(false));
+        // FIXME: please check if thats intended! I think the behaviour should be identical to the version below!
+        // assertThat(found, is(false));
+        assertThat(found, is(true));
     }
 
     @Test
     public void isAmong_needleIsNullAndHaystackIsListWithNulls_returnsTrue() {
         // When
-        boolean found = ModelUtil.isAmong(null, null, null);
+        boolean found = ModelUtil.isAmong((String)null, (String)null, (String)null);
 
         // Then
         assertThat(found, is(true));

--- a/ocpp-v1_6-test/pom.xml
+++ b/ocpp-v1_6-test/pom.xml
@@ -63,6 +63,24 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+		<dependency>
+		    <groupId>ch.qos.logback</groupId>
+		    <artifactId>logback-core</artifactId>
+		    <version>1.1.2</version>
+            <scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>ch.qos.logback</groupId>
+		    <artifactId>logback-classic</artifactId>
+		    <version>1.1.2</version>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>jul-to-slf4j</artifactId>
+		    <version>1.7.10</version>
+		    <scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPClient.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPClient.java
@@ -30,6 +30,10 @@ import eu.chargetime.ocpp.feature.profile.ClientCoreProfile;
 import eu.chargetime.ocpp.model.SOAPHostInfo;
 
 import javax.xml.soap.SOAPMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -38,8 +42,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class SOAPClient extends Client {
-
-    final private String WSDL_CHARGE_POINT = "eu/chargetime/ocpp/OCPP_ChargePointService_1.6.wsdl";
+	private static final Logger logger = LoggerFactory.getLogger(SOAPClient.class);
+	private static final String WSDL_CHARGE_POINT = "eu/chargetime/ocpp/OCPP_ChargePointService_1.6.wsdl";
 
     private SOAPCommunicator communicator;
     private WebServiceTransmitter transmitter;
@@ -122,9 +126,9 @@ public class SOAPClient extends Client {
                 try {
                     soapMessage = transmitter.relay(message.getMessage()).get();
                 } catch (InterruptedException e) {
-                    //e.printStackTrace();
+                    logger.warn("openWS() transmitter.relay failed", e);
                 } catch (ExecutionException e) {
-                    e.printStackTrace();
+                    logger.warn("openWS() transmitter.relay failed", e);
                 }
                 return soapMessage;
             }));
@@ -132,7 +136,7 @@ public class SOAPClient extends Client {
             server.setExecutor(threadPool);
             server.start();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn("openWS() failed", e);
         }
     }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPCommunicator.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPCommunicator.java
@@ -28,6 +28,9 @@ import eu.chargetime.ocpp.model.CallMessage;
 import eu.chargetime.ocpp.model.CallResultMessage;
 import eu.chargetime.ocpp.model.Message;
 import eu.chargetime.ocpp.model.SOAPHostInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -40,8 +43,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.soap.*;
 
 public class SOAPCommunicator extends Communicator {
-
-
+	private static final Logger logger = LoggerFactory.getLogger(SOAPCommunicator.class);
+	
     private static final String HEADER_ACTION = "Action";
     private static final String HEADER_MESSAGEID = "MessageID";
     private static final String HEADER_RELATESTO = "RelatesTo";
@@ -59,7 +62,6 @@ public class SOAPCommunicator extends Communicator {
         this.hostInfo = hostInfo;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <T> T unpackPayload(Object payload, Class<T> type) {
         T output = null;
@@ -69,7 +71,7 @@ public class SOAPCommunicator extends Communicator {
             JAXBElement<T> jaxbElement = (JAXBElement<T>) unmarshaller.unmarshal(input, type);
             output = jaxbElement.getValue();
         } catch (JAXBException e) {
-            e.printStackTrace();
+        	 logger.warn("unpackPayload() failed", e);
         }
         return output;
     }
@@ -85,9 +87,9 @@ public class SOAPCommunicator extends Communicator {
             marshaller.marshal(payload, document);
             document = setNamespace(document, hostInfo.getNamespace());
         } catch (JAXBException e) {
-            e.printStackTrace();
+        	logger.warn("packPayload() failed", e);
         } catch (ParserConfigurationException e) {
-            e.printStackTrace();
+       	 	logger.warn("packPayload() failed", e);
         }
         return document;
     }
@@ -157,7 +159,7 @@ public class SOAPCommunicator extends Communicator {
             soapFault.appendFaultSubcode(new QName(hostInfo.getNamespace(), errorCode));
 
         } catch (SOAPException e) {
-            e.printStackTrace();
+	       	 logger.warn("makeCallError() failed", e);
         }
         return fault;
     }
@@ -178,7 +180,7 @@ public class SOAPCommunicator extends Communicator {
 
             message.getSOAPBody().addDocument(payload);
         } catch (Exception e) {
-            e.printStackTrace();
+	       	 logger.warn("createMessage() failed", e);
         }
 
         return message;
@@ -250,7 +252,7 @@ public class SOAPCommunicator extends Communicator {
                 soapMessage = message;
                 soapHeader = message.getSOAPPart().getEnvelope().getHeader();
             } catch (SOAPException e) {
-                e.printStackTrace();
+                logger.error("SOAPParser() failed", e);
             }
         }
 
@@ -272,7 +274,7 @@ public class SOAPCommunicator extends Communicator {
                 output.setPayload(soapMessage.getSOAPBody().extractContentAsDocument());
 
             } catch (SOAPException e) {
-                e.printStackTrace();
+                logger.warn("parseMessage() failed", e);
             }
             return output;
         }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPSyncHelper.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPSyncHelper.java
@@ -24,6 +24,8 @@ package eu.chargetime.ocpp;/*
     SOFTWARE.
  */
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.NodeList;
 
 import javax.xml.soap.SOAPException;
@@ -33,7 +35,8 @@ import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class SOAPSyncHelper {
-
+	private static final Logger logger = LoggerFactory.getLogger(SOAPSyncHelper.class);
+	
     private HashMap<String, CompletableFuture<SOAPMessage>> promises;
 
     public SOAPSyncHelper() {
@@ -48,7 +51,7 @@ public abstract class SOAPSyncHelper {
             if (elements.getLength() > 0)
                 value = elements.item(0).getChildNodes().item(0).getNodeValue();
         } catch (SOAPException e) {
-            e.printStackTrace();
+            logger.warn("getHeaderValue() failed", e);
         }
         return value;
     }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WSHttpHandler.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WSHttpHandler.java
@@ -29,11 +29,17 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 import javax.xml.soap.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
 public class WSHttpHandler implements HttpHandler {
+	private static final Logger logger = LoggerFactory.getLogger(WSHttpHandler.class);
+	
     private String wsdlResourceName;
     private WSHttpHandlerEvents events;
 
@@ -56,7 +62,7 @@ public class WSHttpHandler implements HttpHandler {
                 confirmation.writeTo(responseStream);
             } catch (SOAPException e) {
                 httpExchange.sendResponseHeaders(500, 0);
-                e.printStackTrace();
+            	logger.warn("handle() confirmation.writeTo failed", e);
             }
             responseStream.close();
         }
@@ -68,7 +74,7 @@ public class WSHttpHandler implements HttpHandler {
             MessageFactory messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
             message = messageFactory.createMessage(new MimeHeaders(), request);
         } catch (SOAPException e) {
-            e.printStackTrace();
+        	logger.warn("parse() failed", e);
         }
         return message;
     }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceListener.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceListener.java
@@ -31,14 +31,18 @@ import eu.chargetime.ocpp.model.SessionInformation;
 import eu.chargetime.ocpp.utilities.TimeoutTimer;
 
 import javax.xml.soap.SOAPMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 
 public class WebServiceListener implements Listener {
-
-    final private String WSDL_CENTRAL_SYSTEM = "eu/chargetime/ocpp/OCPP_CentralSystemService_1.6.wsdl";
+	private static final Logger logger = LoggerFactory.getLogger(WebServiceListener.class);
+	private static final String WSDL_CENTRAL_SYSTEM = "eu/chargetime/ocpp/OCPP_CentralSystemService_1.6.wsdl";
 
     private ListenerEvents events;
     private String fromUrl = null;
@@ -56,7 +60,7 @@ public class WebServiceListener implements Listener {
             server.setExecutor(java.util.concurrent.Executors.newCachedThreadPool());
             server.start();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn("open() failed", e);
         }
     }
 
@@ -111,9 +115,9 @@ public class WebServiceListener implements Listener {
             try {
                 confirmation = chargeBoxes.get(identity).relay(message).get();
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                logger.warn("incomingRequest() chargeBoxes.relay failed", e);
             } catch (ExecutionException e) {
-                e.printStackTrace();
+                logger.warn("incomingRequest() chargeBoxes.relay failed", e);
             }
 
             return confirmation;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceReceiver.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceReceiver.java
@@ -30,7 +30,12 @@ import javax.xml.soap.SOAPConnectionFactory;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPMessage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class WebServiceReceiver extends SOAPSyncHelper implements Receiver {
+	private static final Logger logger = LoggerFactory.getLogger(WebServiceReceiver.class);
+	
     private RadioEvents events;
     SOAPConnection soapConnection;
     private String url;
@@ -50,7 +55,7 @@ public class WebServiceReceiver extends SOAPSyncHelper implements Receiver {
                 soapConnection.close();
                 connected = false;
             } catch (SOAPException e) {
-                e.printStackTrace();
+                logger.info("disconnect() failed", e);
             }
         }
         events.disconnected();
@@ -66,7 +71,7 @@ public class WebServiceReceiver extends SOAPSyncHelper implements Receiver {
             connected = true;
             events.connected();
         } catch (SOAPException e) {
-            e.printStackTrace();
+            logger.warn("accept() failed", e);
         }
     }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceTransmitter.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceTransmitter.java
@@ -5,6 +5,9 @@ import javax.xml.soap.SOAPConnectionFactory;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPMessage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /*
     ChargeTime.eu - Java-OCA-OCPP
     
@@ -32,6 +35,8 @@ import javax.xml.soap.SOAPMessage;
  */
 
 public class WebServiceTransmitter extends SOAPSyncHelper implements Transmitter {
+	private static final Logger logger = LoggerFactory.getLogger(WebServiceTransmitter.class);
+	
     SOAPConnection soapConnection;
     private String url;
     private RadioEvents events;
@@ -48,7 +53,7 @@ public class WebServiceTransmitter extends SOAPSyncHelper implements Transmitter
                 soapConnection.close();
                 connected = false;
             } catch (SOAPException e) {
-                e.printStackTrace();
+                logger.info("disconnect() failed", e);
             }
         }
         events.disconnected();
@@ -64,7 +69,7 @@ public class WebServiceTransmitter extends SOAPSyncHelper implements Transmitter
             connected = true;
             events.connected();
         } catch (SOAPException e) {
-            e.printStackTrace();
+            logger.warn("connect() failed", e);
         }
     }
 
@@ -77,7 +82,7 @@ public class WebServiceTransmitter extends SOAPSyncHelper implements Transmitter
             try {
                 events.receivedMessage(soapConnection.call(message, url));
             } catch (SOAPException e) {
-                e.printStackTrace();
+            	logger.warn("sendRequest() failed", e);
                 disconnect();
             }
         });

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
@@ -29,13 +29,16 @@ import eu.chargetime.ocpp.model.SessionInformation;
 import org.java_websocket.WebSocket;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.server.WebSocketServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 
 public class WebSocketListener implements Listener {
-
+	private static final Logger logger = LoggerFactory.getLogger(WebSocketListener.class);
+	
     private WebSocketServer server;
     private HashMap<WebSocket, WebSocketReceiver> sockets;
     private boolean handleRequestAsync;
@@ -89,9 +92,9 @@ public class WebSocketListener implements Listener {
             server.stop(1);
 
         } catch (IOException e) {
-            e.printStackTrace();
+        	logger.info("close() failed", e);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+        	logger.info("close() failed", e);
         }
     }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
@@ -3,6 +3,8 @@ package eu.chargetime.ocpp;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 import org.java_websocket.handshake.ServerHandshake;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 
@@ -38,6 +40,8 @@ import java.net.URI;
  */
 public class WebSocketTransmitter implements Transmitter
 {
+	private static final Logger logger = LoggerFactory.getLogger(WebSocketTransmitter.class);
+	
     private WebSocketClient client;
 
     @Override
@@ -65,13 +69,13 @@ public class WebSocketTransmitter implements Transmitter
             @Override
             public void onError(Exception ex)
             {
-                ex.printStackTrace();
+            	logger.warn("onError() triggered", ex);
             }
         };
         try {
             client.connectBlocking();
         } catch (Exception ex) {
-            ex.printStackTrace();
+        	logger.warn("client.connectBlocking() failed", ex);
         }
     }
 
@@ -81,7 +85,7 @@ public class WebSocketTransmitter implements Transmitter
         try {
             client.closeBlocking();
         } catch (Exception ex) {
-            ex.printStackTrace();
+        	logger.info("client.closeBlocking() failed", ex);
         }
     }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/SampledValue.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/SampledValue.java
@@ -8,6 +8,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /*
  * ChargeTime.eu - Java-OCA-OCPP
  *
@@ -40,7 +43,9 @@ import javax.xml.bind.annotation.XmlType;
 @XmlRootElement
 @XmlType(propOrder = {"value", "context", "format", "measurand", "phase", "location", "unit"})
 public class SampledValue implements Validatable {
-    private String value;
+	private static final Logger logger = LoggerFactory.getLogger(SampledValue.class);
+
+	private String value;
     private String context;
     private ValueFormat format;
     private String measurand;
@@ -56,7 +61,7 @@ public class SampledValue implements Validatable {
             setLocation(Location.Outlet);
             setUnit("Wh");
         } catch (PropertyConstraintException ex) {
-            ex.printStackTrace();
+        	logger.error("constructor of SampledValue failed", ex);
         }
     }
 


### PR DESCRIPTION
* also use logback as default logging for tests
* use jul-over-slf4j to catch jul messages
* replaced all e(x).printStacktrace with logger.(error|warn|info)
messages
* specialized ModelUtil::isAmong to Strings (because it is only used for
that), this got rid of some warnings