### PR TITLE
Add a namespace fix to get 1.6 soap request through

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ java-docs
 *.project
 *.settings/
 *.classpath
+
+# Should be ignored when using IDE-independent build system such as Maven or Gradle
+.idea/
+*.iml

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPSyncHelper.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPSyncHelper.java
@@ -48,8 +48,9 @@ public abstract class SOAPSyncHelper {
         try {
             SOAPHeader header = message.getSOAPPart().getEnvelope().getHeader();
             NodeList elements = header.getElementsByTagNameNS("*", tagName);
-            if (elements.getLength() > 0)
-                value = elements.item(0).getChildNodes().item(0).getNodeValue();
+            if (elements.getLength() > 0) {
+                value = elements.item(0).getChildNodes().item(0).getTextContent();
+            }
         } catch (SOAPException e) {
             logger.warn("getHeaderValue() failed", e);
         }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceListener.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceListener.java
@@ -111,7 +111,7 @@ public class WebServiceListener implements Listener {
                 });
                 ISession sessionDecorator = new TimeoutSessionDecorator(timeoutTimer, session);
 
-                SessionInformation information = new SessionInformation.Builder().Identifier(identity).InternetAddress(messageInfo.getAddress()).build();
+                SessionInformation information = new SessionInformation.Builder().Identifier(identity).InternetAddress(messageInfo.getAddress()).SOAPtoURL(toUrl).build();
                 events.newSession(session, information);
                 chargeBoxes.put(identity, webServiceReceiver);
             }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/package-info.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/package-info.java
@@ -23,12 +23,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
-@XmlSchema(
-        elementFormDefault = XmlNsForm.QUALIFIED,
-        namespace="urn://Ocpp/Cs/2015/10/",
-        xmlns={
-                @XmlNs(namespaceURI = "urn://Ocpp/Cs/2015/10/", prefix = "ns")
-        })
+@XmlSchema(elementFormDefault = XmlNsForm.QUALIFIED, namespace = "urn://Ocpp/Cs/2015/10/")
 package eu.chargetime.ocpp.model.core;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/package-info.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/package-info.java
@@ -23,8 +23,14 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
-@XmlSchema(elementFormDefault = XmlNsForm.QUALIFIED)
+@XmlSchema(
+        elementFormDefault = XmlNsForm.QUALIFIED,
+        namespace="urn://Ocpp/Cs/2015/10/",
+        xmlns={
+                @XmlNs(namespaceURI = "urn://Ocpp/Cs/2015/10/", prefix = "ns")
+        })
 package eu.chargetime.ocpp.model.core;
 
+import javax.xml.bind.annotation.XmlNs;
 import javax.xml.bind.annotation.XmlNsForm;
 import javax.xml.bind.annotation.XmlSchema;

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/SOAPCommunicatorTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/SOAPCommunicatorTest.java
@@ -16,12 +16,19 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Calendar;
@@ -263,7 +270,7 @@ public class SOAPCommunicatorTest extends TestUtilities {
         Calendar someDate = new Calendar.Builder().setDate(2016, 03, 28).setTimeOfDay(07, 16, 11, 988).setTimeZone(TimeZone.getTimeZone("GMT+00:00")).build();
         int interval = 300;
         RegistrationStatus status = RegistrationStatus.Accepted;
-        String xml = "<bootNotificationResponse xmlns=\"urn://Ocpp/Cs/2015/10\"><currentTime>%s</currentTime><interval>%d</interval><status>%s</status></bootNotificationResponse>";
+        String xml = "<bootNotificationResponse xmlns=\"urn://Ocpp/Cs/2015/10/\"><currentTime>%s</currentTime><interval>%d</interval><status>%s</status></bootNotificationResponse>";
         Document payload = stringToDocument(String.format(xml, currentType, interval, status));
         Class<?> type = BootNotificationConfirmation.class;
 
@@ -305,6 +312,7 @@ public class SOAPCommunicatorTest extends TestUtilities {
 
     public static Document stringToDocument(String xml) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
         DocumentBuilder db = factory.newDocumentBuilder();
 
         InputSource is = new InputSource();


### PR DESCRIPTION
Small changes to get an Ocpp1.6 soap request through, main fix is done to get the namespace interpreted:
* Using getTextContent() in SOAPSyncHelper to get the "From" Address soap header as well
* Xml schema annotation (package-info) fixed to include namespace prefix "ns"
* WebServiceListener fixed to add "toUrl" in SessionInformation. This holds soap server address of the pole
* Ignored Idea editor files that aren't needed in vcs for a maven project
