### PR TITLE
Let #getRetries() return an Integer instead of int

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareRequest.java
@@ -87,7 +87,7 @@ public class UpdateFirmwareRequest implements Request {
      *
      * @return int, retry times.
      */
-    public int getRetries() {
+    public Integer getRetries() {
         return retries;
     }
 


### PR DESCRIPTION
Since retries are optional it may never have been set, meaning the field
could be null.
In order to avoid a NullPointerException the return type Integer is
used.