### PR TITLE
Change SetChargingProfile.req attribute validation according to documentation

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileRequest.java
@@ -65,8 +65,8 @@ public class SetChargingProfileRequest implements Request {
      */
     @XmlElement
     public void setConnectorId(Integer connectorId) {
-        if (connectorId == null || connectorId <= 0) {
-            throw new PropertyConstraintException(connectorId, "connectorId must be > 0");
+        if (connectorId == null || connectorId < 0) {
+            throw new PropertyConstraintException(connectorId, "connectorId must be >= 0");
         }
 
         this.connectorId = connectorId;
@@ -99,7 +99,7 @@ public class SetChargingProfileRequest implements Request {
 
     @Override
     public boolean validate() {
-        boolean valid = connectorId != null && connectorId > 0;
+        boolean valid = connectorId != null && connectorId >= 0;
 
         if (csChargingProfiles != null) {
             valid &= csChargingProfiles.validate();

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/SetChargingProfileRequestTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/SetChargingProfileRequestTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertThat;
 
 public class SetChargingProfileRequestTest {
 
-    private static final String EXPECTED_ERROR_MESSAGE = "Validation failed: [connectorId must be > 0]. Current Value: [%s]";
+    private static final String EXPECTED_ERROR_MESSAGE = "Validation failed: [connectorId must be >= 0]. Current Value: [%s]";
 
     @Rule
     public ExpectedException thrownException = ExpectedException.none();
@@ -49,12 +49,6 @@ public class SetChargingProfileRequestTest {
     @Before
     public void setUp() {
         request = new SetChargingProfileRequest();
-    }
-
-
-    @Test
-    public void setConnectorId_zeroInteger_throwsPropertyConstraintException() {
-        testInvalidConnectorIdValue(0);
     }
 
     @Test


### PR DESCRIPTION
The documentation of "6.43. SetChargingProfile.req" states in its description that the connectorId can be "0" to identify the station itself when setting a ChargePointMaxProfile or a TxDefaultProfile the implementation does not allow "0" at the moment. I changed the validation to be able to set such profiles.