### PR TITLE
Add transactionId to validation method of StartTransactionConfirmation

### DIFF
--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/DummyHandlers.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/DummyHandlers.java
@@ -111,6 +111,7 @@ public class DummyHandlers {
 
                 StartTransactionConfirmation confirmation = new StartTransactionConfirmation();
                 confirmation.setIdTagInfo(tagInfo);
+                confirmation.setTransactionId(42);
                 return failurePoint(confirmation);
             }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionConfirmation.java
@@ -49,6 +49,7 @@ public class StartTransactionConfirmation implements Confirmation {
         boolean valid = true;
         if (valid &= idTagInfo != null)
             valid &= idTagInfo.validate();
+        valid &= transactionId != null;
         return valid;
     }
 

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/StartTransactionConfirmationTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/StartTransactionConfirmationTest.java
@@ -77,7 +77,33 @@ public class StartTransactionConfirmationTest {
     }
 
     @Test
-    public void validate_idTagInfoAndTransactionIdIsSet_idTagInfoIsValidated() throws Exception {
+    public void validate_idTagInfoIsNotSetAndTransactionIdIsSet_returnFalse() {
+        // Given
+        confirmation.setTransactionId(42);
+
+        // When
+        boolean isValid = confirmation.validate();
+
+        // Then
+        assertThat(isValid, is(false));
+    }
+
+    @Test
+    public void validate_idTagInfoIsSetAndTransactionIdIsNotSet_returnFalse() {
+        // Given
+        IdTagInfo idTagInfo = mock(IdTagInfo.class);
+        when(idTagInfo.validate()).thenReturn(true);
+        confirmation.setIdTagInfo(idTagInfo);
+
+        // When
+        boolean isValid = confirmation.validate();
+
+        // Then
+        assertThat(isValid, is(false));
+    }
+
+    @Test
+    public void validate_idTagInfoAndTransactionIdIsSet_idTagInfoIsValidated() {
         // Given
         confirmation.setTransactionId(42);
         IdTagInfo idTagInfo = mock(IdTagInfo.class);
@@ -91,7 +117,7 @@ public class StartTransactionConfirmationTest {
     }
 
     @Test
-    public void validate_idTagInfoAndTransactionIdIsSet_returnTrue() throws Exception {
+    public void validate_idTagInfoAndTransactionIdIsSet_returnTrue() {
         // Given
         confirmation.setTransactionId(42);
         IdTagInfo idTagInfo = mock(IdTagInfo.class);


### PR DESCRIPTION
According to the OCPP 1.6 Standard the `transactionId` is a required field in the `StartTransactionConfirmation`. Some charging stations can not handle a missing `transactionId`. Therefore I added it to the `validate()` method and added some unit tests.