### PR TITLE
Allow zero interval

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
@@ -162,7 +162,7 @@ public class BootNotificationConfirmation implements Confirmation {
     public boolean validate() {
         boolean valid = status != null;
         valid &= currentTime != null;
-        valid &= interval != null && interval > 0;
+        valid &= interval != null && interval >= 0;
 
         return valid;
     }


### PR DESCRIPTION
Fixed boot notification confirmation validation to allow zero as a interval value.