### PR TITLE
Make OCPP library compatible with Android 8

### DIFF
--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/AsyncPromiseFulfillerDecorator.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/AsyncPromiseFulfillerDecorator.java
@@ -36,7 +36,14 @@ public class AsyncPromiseFulfillerDecorator implements PromiseFulfiller {
   @Override
   public void fulfill(
       CompletableFuture<Confirmation> promise, SessionEvents eventHandler, Request request) {
-    new Thread(() -> promiseFulfiller.fulfill(promise, eventHandler, request)).start();
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                promiseFulfiller.fulfill(promise, eventHandler, request);
+              }
+            })
+        .start();
   }
 
   public AsyncPromiseFulfillerDecorator(PromiseFulfiller promiseFulfiller) {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceListener.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceListener.java
@@ -28,6 +28,7 @@ package eu.chargetime.ocpp;
 import com.sun.net.httpserver.HttpServer;
 import eu.chargetime.ocpp.model.SOAPHostInfo;
 import eu.chargetime.ocpp.model.SessionInformation;
+import eu.chargetime.ocpp.utilities.TimeoutHandler;
 import eu.chargetime.ocpp.utilities.TimeoutTimer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -121,9 +122,12 @@ public class WebServiceListener implements Listener {
         TimeoutTimer timeoutTimer =
             new TimeoutTimer(
                 INITIAL_TIMEOUT,
-                () -> {
-                  session.close();
-                  chargeBoxes.remove(identity);
+                new TimeoutHandler() {
+                  @Override
+                  public void timeout() {
+                    session.close();
+                    chargeBoxes.remove(identity);
+                  }
                 });
 
         // TODO: Decorator created but not used

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceReceiver.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceReceiver.java
@@ -89,11 +89,14 @@ public class WebServiceReceiver extends SOAPSyncHelper implements Receiver {
     if (!connected) throw new NotConnectedException();
 
     new Thread(
-            () -> {
-              try {
-                events.receivedMessage(soapConnection.call(message, url));
-              } catch (SOAPException e) {
-                disconnect();
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  events.receivedMessage(soapConnection.call(message, url));
+                } catch (SOAPException e) {
+                  disconnect();
+                }
               }
             })
         .start();

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceTransmitter.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceTransmitter.java
@@ -82,13 +82,16 @@ public class WebServiceTransmitter extends SOAPSyncHelper implements Transmitter
     if (!connected) throw new NotConnectedException();
     Thread thread =
         new Thread(
-            () -> {
-              try {
-                SOAPMessage response = soapConnection.call(message, url);
-                events.receivedMessage(response);
-              } catch (SOAPException e) {
-                logger.warn("sendRequest() failed", e);
-                disconnect();
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  SOAPMessage response = soapConnection.call(message, url);
+                  events.receivedMessage(response);
+                } catch (SOAPException e) {
+                  logger.warn("sendRequest() failed", e);
+                  disconnect();
+                }
               }
             });
     thread.start();


### PR DESCRIPTION
Android 8's Jack has issues processing class files with lambda
operations that implicitly use classes which are not part of the
project, resulting in build failures.

Replace the four occurrences where such lambdas are used with
functionally identical but less shorthand code, so that the OCPP
library will build for Android 8.