### PR TITLE
Really allow zero interval + fix integer comparisons

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
@@ -172,7 +172,7 @@ public class BootNotificationConfirmation implements Confirmation {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     BootNotificationConfirmation that = (BootNotificationConfirmation) o;
-    return interval == that.interval
+    return Objects.equals(interval, that.interval)
         && Objects.equals(currentTime, that.currentTime)
         && status == that.status;
   }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
@@ -122,7 +122,7 @@ public class BootNotificationConfirmation implements Confirmation {
    */
   @XmlElement
   public void setInterval(Integer interval) {
-    if (interval <= 0) {
+    if (interval < 0) {
       throw new PropertyConstraintException(interval, "interval be a positive value");
     }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityRequest.java
@@ -131,7 +131,7 @@ public class ChangeAvailabilityRequest implements Request {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ChangeAvailabilityRequest that = (ChangeAvailabilityRequest) o;
-    return connectorId == that.connectorId && type == that.type;
+    return Objects.equals(connectorId, that.connectorId) && type == that.type;
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesRequest.java
@@ -148,8 +148,8 @@ public class MeterValuesRequest implements Request {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     MeterValuesRequest that = (MeterValuesRequest) o;
-    return connectorId == that.connectorId
-        && transactionId == that.transactionId
+    return Objects.equals(connectorId, that.connectorId)
+        && Objects.equals(transactionId, that.transactionId)
         && Arrays.equals(meterValue, that.meterValue);
   }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsRequest.java
@@ -178,8 +178,8 @@ public class GetDiagnosticsRequest implements Request {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     GetDiagnosticsRequest that = (GetDiagnosticsRequest) o;
-    return retries == that.retries
-        && retryInterval == that.retryInterval
+    return Objects.equals(retries, that.retries)
+        && Objects.equals(retryInterval, that.retryInterval)
         && Objects.equals(location, that.location)
         && Objects.equals(startTime, that.startTime)
         && Objects.equals(stopTime, that.stopTime);


### PR DESCRIPTION
It seems that #105 wasn't fully fixed in #107. I also noticed that the equals method is broken since it tries to compare objects using `==` (that works only for values -128...127).