### PR TITLE
Fix NPE on incoming DataTransferRequest

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientCoreProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientCoreProfile.java
@@ -60,7 +60,7 @@ public class ClientCoreProfile implements Profile {
     features.add(new ChangeAvailabilityFeature(this));
     features.add(new ChangeConfigurationFeature(this));
     features.add(new ClearCacheFeature(this));
-    features.add(new DataTransferFeature(null));
+    features.add(new DataTransferFeature(this));
     features.add(new GetConfigurationFeature(this));
     features.add(new HeartbeatFeature(null));
     features.add(new MeterValuesFeature(null));


### PR DESCRIPTION
DataTransferRequests can be both initiated by the charge point as well
as the central system.

Using the ClientCoreProfile, a received DataTransferRequest cannot be
handled because the owning profile is unset.

Fix this by setting the owning profile.