### PR TITLE
Add support for HTTP Basic Authentication

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
@@ -34,6 +34,8 @@ public class JSONConfiguration {
   public static final String REUSE_ADDR_PARAMETER = "REUSE_ADDR";
   public static final String PROXY_PARAMETER = "PROXY";
   public static final String PING_INTERVAL_PARAMETER = "PING_INTERVAL";
+  public static final String USERNAME_PARAMETER = "USERNAME";
+  public static final String PASSWORD_PARAMETER = "PASSWORD";
 
   private final HashMap<String, Object> parameters = new HashMap<>();
 

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
@@ -31,6 +31,10 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.Proxy;
 import java.net.URI;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.drafts.Draft;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
@@ -63,8 +67,17 @@ public class WebSocketTransmitter implements Transmitter {
   public void connect(String uri, RadioEvents events) {
     final URI resource = URI.create(uri);
 
+    Map<String,String> httpHeaders = new HashMap<>();
+    String username = configuration.getParameter(JSONConfiguration.USERNAME_PARAMETER);
+    String password = configuration.getParameter(JSONConfiguration.PASSWORD_PARAMETER);
+    if (username != null && password != null) {
+      String credentials = username + ":" + password;
+      byte[] base64Credentials = Base64.getEncoder().encode(credentials.getBytes());
+      httpHeaders.put("Authorization", "Basic " + new String(base64Credentials));
+    }
+
     client =
-        new WebSocketClient(resource, draft) {
+        new WebSocketClient(resource, draft, httpHeaders) {
           @Override
           public void onOpen(ServerHandshake serverHandshake) {
             logger.debug("On connection open (HTTP status: {})", serverHandshake.getHttpStatus());


### PR DESCRIPTION
This change adds support for HTTP Basic Authentication to the OCPP-J
client, via two additional JSONConfiguration parameters for username and
password. When both are set, the HTTP Basic Authentication header will
be added to the websocket connect request.

Note that HTTP Basic Authentication transmits username and password
without encryption, so for secure communication, it must be used within
a trusted channel, e.g. a secure websocket connection (WSS) or maybe an
encrypted VPN connection.

This change has originally been prepared by our former colleague:

https://github.com/rtzll/Java-OCA-OCPP/commit/8652108a08e295c063eaa7848b231d5b4c47526f

and has successfully been tested in a plugfest.