### PR TITLE
Bump Java-WebSocket consistently to 1.5.1

### DIFF
--- a/OCPP-J/build.gradle
+++ b/OCPP-J/build.gradle
@@ -5,7 +5,7 @@
 dependencies {
     compile project(':common')
     compile 'com.google.code.gson:gson:2.8.0'
-    compile 'org.java-websocket:Java-WebSocket:1.3.8'
+    compile 'org.java-websocket:Java-WebSocket:1.5.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.hamcrest:hamcrest-core:1.3'

--- a/OCPP-J/pom.xml
+++ b/OCPP-J/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
@@ -34,7 +34,6 @@ import java.net.URI;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.drafts.Draft;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
@@ -67,7 +66,7 @@ public class WebSocketTransmitter implements Transmitter {
   public void connect(String uri, RadioEvents events) {
     final URI resource = URI.create(uri);
 
-    Map<String,String> httpHeaders = new HashMap<>();
+    Map<String, String> httpHeaders = new HashMap<>();
     String username = configuration.getParameter(JSONConfiguration.USERNAME_PARAMETER);
     String password = configuration.getParameter(JSONConfiguration.PASSWORD_PARAMETER);
     if (username != null && password != null) {

--- a/ocpp-v1_6/build.gradle
+++ b/ocpp-v1_6/build.gradle
@@ -5,7 +5,7 @@
 dependencies {
     compile project(':common')
     compile project(':OCPP-J')
-    compile 'org.java-websocket:Java-WebSocket:1.3.8'
+    compile 'org.java-websocket:Java-WebSocket:1.5.1'
     compile group: 'javax.xml.soap', name: 'javax.xml.soap-api', version: '1.4.0'
     
     testCompile 'junit:junit:4.12'

--- a/ocpp-v1_6/pom.xml
+++ b/ocpp-v1_6/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/ocpp-v2_0/build.gradle
+++ b/ocpp-v2_0/build.gradle
@@ -5,7 +5,7 @@
 dependencies {
     compile project(':common')
     compile project(':OCPP-J')
-    compile 'org.java-websocket:Java-WebSocket:1.3.8'
+    compile 'org.java-websocket:Java-WebSocket:1.5.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.hamcrest:hamcrest-core:1.3'

--- a/ocpp-v2_0/pom.xml
+++ b/ocpp-v2_0/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The last update of the Java-WebSocket dependency to 1.5.0 changed only
the maven pom files and missed the gradle build files, which remained
at 1.3.8.

This change updates the dependency to 1.5.1 in all places, also picking
up the Java-WebSocket 1.5.1 fix for Android.