### PR TITLE
Allow omitting all optional SampledValue fields

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/SampledValue.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/SampledValue.java
@@ -53,17 +53,7 @@ public class SampledValue implements Validatable {
 
   /** @deprecated use {@link #SampledValue(String)} to be sure to set required fields */
   @Deprecated
-  public SampledValue() {
-    try {
-      setContext("Sample.Periodic");
-      setFormat(ValueFormat.Raw);
-      setMeasurand("Energy.Active.Import.Register");
-      setLocation(Location.Outlet);
-      setUnit("Wh");
-    } catch (PropertyConstraintException ex) {
-      logger.error("constructor of SampledValue failed", ex);
-    }
-  }
+  public SampledValue() {}
 
   /**
    * Handle required fields.
@@ -73,11 +63,6 @@ public class SampledValue implements Validatable {
   public SampledValue(String value) {
     try {
       setValue(value);
-      setContext("Sample.Periodic");
-      setFormat(ValueFormat.Raw);
-      setMeasurand("Energy.Active.Import.Register");
-      setLocation(Location.Outlet);
-      setUnit("Wh");
     } catch (PropertyConstraintException ex) {
       logger.error("constructor of SampledValue failed", ex);
     }
@@ -117,7 +102,7 @@ public class SampledValue implements Validatable {
    * @return enum value for context.
    */
   public String getContext() {
-    return context;
+    return context == null ? "Sample.Periodic" : context;
   }
 
   /**
@@ -132,7 +117,7 @@ public class SampledValue implements Validatable {
   // TODO: Change to enum, solve format issue and change exception message.
   @XmlElement
   public void setContext(String context) {
-    if (!isValidContext(context)) {
+    if (context != null && !isValidContext(context)) {
       throw new PropertyConstraintException(context, "context is not properly defined");
     }
 
@@ -159,7 +144,7 @@ public class SampledValue implements Validatable {
    * @return the {@link ValueFormat}.
    */
   public ValueFormat getFormat() {
-    return format;
+    return format == null ? ValueFormat.Raw : format;
   }
 
   /**
@@ -179,7 +164,7 @@ public class SampledValue implements Validatable {
    */
   @Deprecated
   public ValueFormat objFormat() {
-    return format;
+    return format == null ? ValueFormat.Raw : format;
   }
 
   /**
@@ -188,7 +173,7 @@ public class SampledValue implements Validatable {
    * @return enum value of measurand.
    */
   public String getMeasurand() {
-    return measurand;
+    return measurand == null ? "Energy.Active.Import.Register" : measurand;
   }
 
   /**
@@ -208,7 +193,7 @@ public class SampledValue implements Validatable {
   // TODO: Change to enum, solve format issue and change exception message.
   @XmlElement
   public void setMeasurand(String measurand) {
-    if (!isValidMeasurand(measurand))
+    if (measurand != null && !isValidMeasurand(measurand))
       throw new PropertyConstraintException(measurand, "measurand value is not properly defined");
 
     this.measurand = measurand;
@@ -265,7 +250,7 @@ public class SampledValue implements Validatable {
   // TODO: Change to enum, solve format issue and change exception message.
   @XmlElement
   public void setPhase(String phase) {
-    if (!isValidPhase(phase)) {
+    if (phase != null && !isValidPhase(phase)) {
       throw new PropertyConstraintException(phase, "phase is not properly defined");
     }
 
@@ -283,7 +268,7 @@ public class SampledValue implements Validatable {
    * @return the {@link Location}.
    */
   public Location getLocation() {
-    return location;
+    return location == null ? Location.Outlet : location;
   }
 
   /**
@@ -303,7 +288,7 @@ public class SampledValue implements Validatable {
    */
   @Deprecated
   public Location objLocation() {
-    return location;
+    return location == null ? Location.Outlet : location;
   }
 
   /**
@@ -312,7 +297,7 @@ public class SampledValue implements Validatable {
    * @return Unit of Measure.
    */
   public String getUnit() {
-    return unit;
+    return unit == null && getMeasurand().startsWith("Energy") ? "Wh" : unit;
   }
 
   /**
@@ -328,7 +313,7 @@ public class SampledValue implements Validatable {
   // TODO: Change to enum, solve format issue and change exception message.
   @XmlElement
   public void setUnit(String unit) {
-    if (!isValidUnit(unit)) {
+    if (unit != null && !isValidUnit(unit)) {
       throw new PropertyConstraintException(unit, "unit is not properly defined");
     }
 


### PR DESCRIPTION
According to the OCPP specification, all fields of the SampledValue
class except for "value" are optional and may be omitted.

However, the Java class implementation in this library initialized all
fields but "phase" to their default values, and prevented resetting all
but the enum fields to null. Most prominently, the "unit" field was
initialized to "Wh" and could not be reset, preventing the generation of
compliant messages for "Frequency" and "Power.Factor" measurands, for
which the "unit" field needs to be omitted.

Remove the initialization of fields to their default values from the
class constructors, so that they are left as null and will be omitted
when serializing the object.

Exempt null references from the validations in the field setter methods,
so that all fields can be set to null.

Add returning the default value in the field getter methods in case the
stored field value is null, where applicable.

Most importantly, for the "unit" field, only replace null with "Wh" for
"Energy" type measurands. This ensures the null is retained for the
"Frequency" and "Power.Factor" measurands, in compliance with the OCPP
specification.