### PR TITLE
Fix ZonedDateTimeSerializer (ISO 8601)

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONCommunicator.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONCommunicator.java
@@ -7,6 +7,7 @@ import eu.chargetime.ocpp.model.CallResultMessage;
 import eu.chargetime.ocpp.model.Message;
 import java.lang.reflect.Type;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,7 @@ public class JSONCommunicator extends Communicator {
     @Override
     public JsonElement serialize(
         ZonedDateTime zonedDateTime, Type type, JsonSerializationContext jsonSerializationContext) {
-      return new JsonPrimitive(zonedDateTime.toString());
+      return new JsonPrimitive(zonedDateTime.format(DateTimeFormatter.ISO_INSTANT));
     }
   }
 


### PR DESCRIPTION
ZonedDateTimeSezializer is not compatible with ISO 8601. 
Before fix ZonedDateTime was serialized as follows eg:
`2021-05-31T11:29:13.009857200+02:00[Europe/Belgrade]`
And should be:
`2021-05-31T09:29:13.009857200Z`

OCPP charger simulator https://github.com/NewMotion/docile-charge-point was not being able to parse date fields.

