### PR TITLE
Rename enum ChangingRateUnitType to ChargingRateUnitType (Typo)

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ChargingRateUnitType.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ChargingRateUnitType.java
@@ -25,7 +25,7 @@ package eu.chargetime.ocpp.model.smartcharging;
    SOFTWARE.
 */
 
-public enum ChangingRateUnitType {
+public enum ChargingRateUnitType {
   W,
   A
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/GetCompositeScheduleRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/GetCompositeScheduleRequest.java
@@ -38,7 +38,7 @@ public class GetCompositeScheduleRequest implements Request {
 
   private Integer connectorId;
   private Integer duration;
-  private ChangingRateUnitType changingRateUnitType;
+  private ChargingRateUnitType chargingRateUnit;
 
   /**
    * @deprecated use {@link #GetCompositeScheduleRequest(Integer, Integer)} to be sure to set
@@ -107,18 +107,18 @@ public class GetCompositeScheduleRequest implements Request {
    *
    * @return current profile
    */
-  public ChangingRateUnitType getChangingRateUnitType() {
-    return changingRateUnitType;
+  public ChargingRateUnitType getChargingRateUnit() {
+    return chargingRateUnit;
   }
 
   /**
    * Optional. Can be used to force a power or current profile
    *
-   * @param changingRateUnitType the {@link ChangingRateUnitType}
+   * @param chargingRateUnit the {@link ChargingRateUnitType}
    */
   @XmlElement
-  public void setChangingRateUnitType(ChangingRateUnitType changingRateUnitType) {
-    this.changingRateUnitType = changingRateUnitType;
+  public void setChargingRateUnit(ChargingRateUnitType chargingRateUnit) {
+    this.chargingRateUnit = chargingRateUnit;
   }
 
   @Override
@@ -136,7 +136,7 @@ public class GetCompositeScheduleRequest implements Request {
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectorId, duration, changingRateUnitType);
+    return Objects.hash(connectorId, duration, chargingRateUnit);
   }
 
   @Override
@@ -144,7 +144,7 @@ public class GetCompositeScheduleRequest implements Request {
     return MoreObjects.toStringHelper(this)
         .add("connectorId", connectorId)
         .add("duration", duration)
-        .add("changingRateUnitType", changingRateUnitType)
+        .add("chargingRateUnit", chargingRateUnit)
         .add("isValid", validate())
         .toString();
   }

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/GetCompositeScheduleRequestTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/test/GetCompositeScheduleRequestTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.smartcharging.ChangingRateUnitType;
+import eu.chargetime.ocpp.model.smartcharging.ChargingRateUnitType;
 import eu.chargetime.ocpp.model.smartcharging.GetCompositeScheduleRequest;
 import org.junit.Before;
 import org.junit.Rule;
@@ -87,15 +87,15 @@ public class GetCompositeScheduleRequestTest {
   }
 
   @Test
-  public void setChangingRateUnitType_A_changingRateUnitTypeIsSet() {
+  public void setChargingRateUnitType_A_chargingRateUnitTypeIsSet() {
     // Given
-    ChangingRateUnitType chargingRateUnitType = ChangingRateUnitType.A;
+    ChargingRateUnitType chargingRateUnit = ChargingRateUnitType.A;
 
     // When
-    request.setChangingRateUnitType(chargingRateUnitType);
+    request.setChargingRateUnit(chargingRateUnit);
 
     // Then
-    assertThat(request.getChangingRateUnitType(), equalTo(chargingRateUnitType));
+    assertThat(request.getChargingRateUnit(), equalTo(chargingRateUnit));
   }
 
   @Test
@@ -112,7 +112,7 @@ public class GetCompositeScheduleRequestTest {
     // Given
     request.setConnectorId(42);
     request.setDuration(0);
-    request.setChangingRateUnitType(ChangingRateUnitType.A);
+    request.setChargingRateUnit(ChargingRateUnitType.A);
 
     // When
     boolean isValid = request.validate();


### PR DESCRIPTION
Rename enum ChangingRateUnitType to ChargingRateUnitType and field changingRateUnitType to chargingRateUnit.

Now there are two enums ChargingRateUnitType one in core and one in smartcharging packages.

OCPP charger simulator https://github.com/NewMotion/docile-charge-point was not being able to parse GetCompositeSchedule request correctly