### PR TITLE
Allow optional IdTagInfo in SendLocalList for deleting entries

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/AuthorizationData.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/AuthorizationData.java
@@ -88,7 +88,7 @@ public class AuthorizationData implements Validatable {
 
   @Override
   public boolean validate() {
-    return ModelUtil.validate(idTag, 20) && idTagInfo.validate();
+    return ModelUtil.validate(idTag, 20) && (idTagInfo == null || idTagInfo.validate());
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListRequest.java
@@ -127,6 +127,10 @@ public class SendLocalListRequest implements Request {
     if (localAuthorizationList != null) {
       for (AuthorizationData data : localAuthorizationList) {
         valid &= data.validate();
+
+        if (updateType == UpdateType.Full) {
+          valid &= data.getIdTagInfo() != null;
+        }
       }
     }
 

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/localauthlist/test/SendLocalListRequestTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/localauthlist/test/SendLocalListRequestTest.java
@@ -4,8 +4,13 @@ import static eu.chargetime.ocpp.utilities.TestUtilities.aList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
+import eu.chargetime.ocpp.model.core.AuthorizationStatus;
+import eu.chargetime.ocpp.model.core.IdTagInfo;
 import eu.chargetime.ocpp.model.localauthlist.AuthorizationData;
 import eu.chargetime.ocpp.model.localauthlist.SendLocalListRequest;
 import eu.chargetime.ocpp.model.localauthlist.UpdateType;
@@ -106,5 +111,48 @@ public class SendLocalListRequestTest {
     request.setLocalAuthorizationList(aList(data));
     // Then
     assertThat(request.validate(), equalTo(false));
+  }
+
+  @Test
+  public void validate_updateTypeFullWithTagInfo_isValid() {
+    // When
+    request.setListVersion(42);
+    request.setUpdateType(UpdateType.Full);
+    request.setLocalAuthorizationList(aList(data));
+
+    when(data.validate()).thenReturn(true);
+    when(data.getIdTagInfo()).thenReturn(new IdTagInfo(AuthorizationStatus.Accepted));
+
+    // Then
+    assertThat(request.validate(), equalTo(true));
+    verify(data, times(1)).getIdTagInfo();
+    verify(data, times(1)).validate();
+  }
+
+  @Test
+  public void validate_updateTypeFullEmptyTagInfo_isNotValid() {
+    // When
+    request.setListVersion(42);
+    request.setUpdateType(UpdateType.Full);
+    request.setLocalAuthorizationList(aList(data));
+
+    when(data.validate()).thenReturn(true);
+    when(data.getIdTagInfo()).thenReturn(null);
+
+    // Then
+    assertThat(request.validate(), equalTo(false));
+  }
+
+  @Test
+  public void validate_updateTypeDifferentialEmptyIdTagInfo_isValid() {
+    // When
+    request.setListVersion(42);
+    request.setUpdateType(UpdateType.Differential);
+    request.setLocalAuthorizationList(aList(data));
+
+    when(data.validate()).thenReturn(true);
+
+    // Then
+    assertThat(request.validate(), equalTo(true));
   }
 }


### PR DESCRIPTION
Fixes #151 

As per the OCPP 1.6 specs, IdTagInfo in AuthorizationData is optional when doing a SendLocalList with differential UpdateType to delete the entry.

From 7.1
`Optional. (Required when UpdateType is Full) This contains information about authorization status, expiry and parent id. For a Differential update the following applies: If this element is present, then this entry SHALL be added or updated in the Local Authorization List. If this element is absent, than the entry for this idtag in the Local Authorization List SHALL be deleted.`
                   