### PR TITLE
Fix Maven build/dependency error

### DIFF
--- a/OCPP-J/pom.xml
+++ b/OCPP-J/pom.xml
@@ -2,15 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>all</artifactId>
-        <groupId>eu.chargetime.ocpp</groupId>
-        <version>1.0</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>eu.chargetime.ocpp</groupId>
     <artifactId>OCPP-J</artifactId>
     <version>1.0</version>
+    <packaging>jar</packaging>
 
     <name>Java-OCA-OCPP OCPP-J</name>
     <description>Implementation of Open Charge-Point Protocols OCPP-J</description>

--- a/ocpp-v2_0-test/pom.xml
+++ b/ocpp-v2_0-test/pom.xml
@@ -2,15 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>all</artifactId>
-        <groupId>eu.chargetime.ocpp</groupId>
-        <version>1.0</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>eu.chargetime.ocpp</groupId>
     <artifactId>v2_0-test</artifactId>
     <version>1.0</version>
+    <packaging>jar</packaging>
 
     <name>Java-OCA-OCPP v2.0 - Integration test</name>
     <description>Integration test of OCA OCPP version 2.0</description>

--- a/ocpp-v2_0/pom.xml
+++ b/ocpp-v2_0/pom.xml
@@ -2,15 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>all</artifactId>
-        <groupId>eu.chargetime.ocpp</groupId>
-        <version>1.0</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>eu.chargetime.ocpp</groupId>
     <artifactId>v2_0</artifactId>
     <version>1.0</version>
+    <packaging>jar</packaging>
 
     <name>Java-OCA-OCPP v2.0</name>
     <description>Implementation of Open Charge-Point Protocol version 2.0.</description>
@@ -48,7 +45,6 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
     </distributionManagement>
-
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Partially fixes #136 
This removes the dependency on the parent pom for OCPP-J, ocpp-v2_0 and ocpp-v2_0-test modules.

@TVolden you would need to re-deploy to Maven repo for OCPP-J and maybe deploy the 2.0 jars if needed. After deploying and it verifying it works, you can update the versions in the pom to something like 1.1-SNAPSHOT.
