### PR TITLE
Remove logback dependency

### DIFF
--- a/ocpp-common/pom.xml
+++ b/ocpp-common/pom.xml
@@ -63,11 +63,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-        </dependency>
 
         <!-- Tests -->
         <dependency>


### PR DESCRIPTION
Let the users of Java-OCA-OCPP choose which logging to use.