### PR TITLE
Enable ws connection timeout

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
@@ -36,6 +36,7 @@ public class JSONConfiguration {
   public static final String PING_INTERVAL_PARAMETER = "PING_INTERVAL";
   public static final String USERNAME_PARAMETER = "USERNAME";
   public static final String PASSWORD_PARAMETER = "PASSWORD";
+  public static final String CONNECT_TIMEOUT_IN_MS_PARAMETER = "CONNECT_TIMEOUT_IN_MS";
 
   private final HashMap<String, Object> parameters = new HashMap<>();
 

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
@@ -84,8 +84,11 @@ public class WebSocketTransmitter implements Transmitter {
       httpHeaders.put("Authorization", "Basic " + new String(base64Credentials));
     }
 
+    int connectTimeout =
+        this.configuration.getParameter(JSONConfiguration.CONNECT_TIMEOUT_IN_MS_PARAMETER, 0);
+
     client =
-        new WebSocketClient(resource, draft, httpHeaders) {
+        new WebSocketClient(resource, draft, httpHeaders, connectTimeout) {
           @Override
           public void onOpen(ServerHandshake serverHandshake) {
             logger.debug("On connection open (HTTP status: {})", serverHandshake.getHttpStatus());


### PR DESCRIPTION
Add a new configuration parameter CONNECTION_TIMEOUT_IN_MS to specify the websocket connection timeout in milliseconds and use it when creating `WebSocketClient`. The default value is `0`, which means _no timeout_.

Fixes #158 