### PR TITLE
make number of web-socket-workers / decoders configurable

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
@@ -37,6 +37,7 @@ public class JSONConfiguration {
   public static final String USERNAME_PARAMETER = "USERNAME";
   public static final String PASSWORD_PARAMETER = "PASSWORD";
   public static final String CONNECT_TIMEOUT_IN_MS_PARAMETER = "CONNECT_TIMEOUT_IN_MS";
+  public static final String WEBSOCKET_WORKER_COUNT = "WEBSOCKET_WORKER_COUNT";
 
   private final HashMap<String, Object> parameters = new HashMap<>();
 

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 public class WebSocketListener implements Listener {
   private static final Logger logger = LoggerFactory.getLogger(WebSocketListener.class);
 
+  private static final int DEFAULT_WEBSOCKET_WORKER_COUNT = 4;
   private static final int TIMEOUT_IN_MILLIS = 10000;
 
   private static final int OCPPJ_CP_MIN_PASSWORD_LENGTH = 16;
@@ -78,7 +79,10 @@ public class WebSocketListener implements Listener {
   @Override
   public void open(String hostname, int port, ListenerEvents handler) {
     server =
-        new WebSocketServer(new InetSocketAddress(hostname, port), drafts) {
+        new WebSocketServer(
+                new InetSocketAddress(hostname, port),
+                configuration.getParameter(JSONConfiguration.WEBSOCKET_WORKER_COUNT, DEFAULT_WEBSOCKET_WORKER_COUNT),
+                drafts) {
           @Override
           public void onOpen(WebSocket webSocket, ClientHandshake clientHandshake) {
             logger.debug(


### PR DESCRIPTION
`WebSocketServer `[1] offers possibility to adjust number of decoders.  It's useful to be able co configure this.

[1] https://www.javadoc.io/doc/org.java-websocket/Java-WebSocket/1.3.4/org/java_websocket/server/WebSocketServer.html#WebSocketServer-java.net.InetSocketAddress-int-