### PR TITLE
reset failed flag before sending retry messages

### DIFF
--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
@@ -330,6 +330,7 @@ public abstract class Communicator {
       Object call;
       try {
         while ((call = getRetryMessage()) != null) {
+          failedFlag = false;
           radio.send(call);
           Thread.sleep(DELAY_IN_MILLISECONDS);
           if (!hasFailed()) popRetryMessage();


### PR DESCRIPTION
TL;DR: the error flag in `Communicator `never gets set back to `false`  after it has been to to `true`

We've encountered some rare cases where...
* the charge-point has been offline
* the central-system responded with some kind of error
* now the client tries to resend non-send-messages via `RetryRunner`  but will never "pop the message"  (see code) so it will send the same message again and again 

