### PR TITLE
raise gmavenplus-plugin from 1.6 to 1.13.1

### DIFF
--- a/ocpp-v1_6-test/pom.xml
+++ b/ocpp-v1_6-test/pom.xml
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.13.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/ocpp-v2_0-test/pom.xml
+++ b/ocpp-v2_0-test/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.13.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
for better compatibility with Azure DevOps Artifacts Feeds (older plugin version references unresolved properties in transitive dependencies which Azure DevOps cannot handle)
```
Failed to transfer file: <your-devops-url>/maven/v1/org/sonatype/sisu/inject/guice-parent/2.9.1/guice-parent-2.9.1.pom. Return code is: 400 , ReasonPhrase:Bad Request - System.InvalidOperationException: There is an error in XML document (0, 0). ---> System.FormatException: The string '${guice.with.jarjar}' is not a valid Boolean value.    
at System.Xml.XmlConvert.ToBoolean(String s)    
at Microsoft.Xml.Serialization.GeneratedAssembly.XmlSerializationReaderMavenPomMetadata.Read4_MavenPomDependency(Boolean isNullable, Boolean checkType)    
at Microsoft.Xml.Serialization.GeneratedAssembly.XmlSerializatio...
```