### PR TITLE
Features/fix profile initialization (nulls and cross-over in FirmwareManagementProfiles)

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
@@ -82,9 +82,10 @@ public class WebSocketListener implements Listener {
   public void open(String hostname, int port, ListenerEvents handler) {
     server =
         new WebSocketServer(
-                new InetSocketAddress(hostname, port),
-                configuration.getParameter(JSONConfiguration.WEBSOCKET_WORKER_COUNT, DEFAULT_WEBSOCKET_WORKER_COUNT),
-                drafts) {
+            new InetSocketAddress(hostname, port),
+            configuration.getParameter(
+                JSONConfiguration.WEBSOCKET_WORKER_COUNT, DEFAULT_WEBSOCKET_WORKER_COUNT),
+            drafts) {
           @Override
           public void onOpen(WebSocket webSocket, ClientHandshake clientHandshake) {
             logger.debug(
@@ -115,9 +116,9 @@ public class WebSocketListener implements Listener {
             String proxiedAddress = clientHandshake.getFieldValue(HTTP_HEADER_PROXIED_ADDRESS);
 
             logger.debug(
-                    "New web-socket connection opened from address: {} proxied for: {}",
-                    webSocket.getRemoteSocketAddress(),
-                    proxiedAddress);
+                "New web-socket connection opened from address: {} proxied for: {}",
+                webSocket.getRemoteSocketAddress(),
+                proxiedAddress);
 
             SessionInformation information =
                 new SessionInformation.Builder()
@@ -131,13 +132,14 @@ public class WebSocketListener implements Listener {
           }
 
           @Override
-          public ServerHandshakeBuilder onWebsocketHandshakeReceivedAsServer(WebSocket webSocket, Draft draft,
-                                                                             ClientHandshake clientHandshake) throws InvalidDataException {
+          public ServerHandshakeBuilder onWebsocketHandshakeReceivedAsServer(
+              WebSocket webSocket, Draft draft, ClientHandshake clientHandshake)
+              throws InvalidDataException {
             SessionInformation information =
-                    new SessionInformation.Builder()
-                            .Identifier(clientHandshake.getResourceDescriptor())
-                            .InternetAddress(webSocket.getRemoteSocketAddress())
-                            .build();
+                new SessionInformation.Builder()
+                    .Identifier(clientHandshake.getResourceDescriptor())
+                    .InternetAddress(webSocket.getRemoteSocketAddress())
+                    .build();
 
             String username = null;
             byte[] password = null;
@@ -150,7 +152,8 @@ public class WebSocketListener implements Listener {
                 // split credentials on username and password
                 for (int i = 0; i < credDecoded.length; i++) {
                   if (credDecoded[i] == ':') {
-                    username = new String(Arrays.copyOfRange(credDecoded, 0, i), StandardCharsets.UTF_8);
+                    username =
+                        new String(Arrays.copyOfRange(credDecoded, 0, i), StandardCharsets.UTF_8);
                     if (i + 1 < credDecoded.length) {
                       password = Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length);
                     }
@@ -158,17 +161,17 @@ public class WebSocketListener implements Listener {
                   }
                 }
               }
-              if (password == null || password.length < OCPPJ_CP_MIN_PASSWORD_LENGTH || password.length > OCPPJ_CP_MAX_PASSWORD_LENGTH)
+              if (password == null
+                  || password.length < OCPPJ_CP_MIN_PASSWORD_LENGTH
+                  || password.length > OCPPJ_CP_MAX_PASSWORD_LENGTH)
                 throw new InvalidDataException(401, "Invalid password length");
             }
 
             try {
               handler.authenticateSession(information, username, password);
-            }
-            catch (AuthenticationException e) {
+            } catch (AuthenticationException e) {
               throw new InvalidDataException(e.getErrorCode(), e.getMessage());
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
               throw new InvalidDataException(401, e.getMessage());
             }
             return super.onWebsocketHandshakeReceivedAsServer(webSocket, draft, clientHandshake);

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ListenerEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ListenerEvents.java
@@ -28,6 +28,8 @@ package eu.chargetime.ocpp;
 import eu.chargetime.ocpp.model.SessionInformation;
 
 public interface ListenerEvents {
-  void authenticateSession(SessionInformation information, String username, byte[] password) throws AuthenticationException;
+  void authenticateSession(SessionInformation information, String username, byte[] password)
+      throws AuthenticationException;
+
   void newSession(ISession session, SessionInformation information);
 }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ServerEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ServerEvents.java
@@ -29,7 +29,8 @@ import eu.chargetime.ocpp.model.SessionInformation;
 import java.util.UUID;
 
 public interface ServerEvents {
-  default void authenticateSession(SessionInformation information, String username, byte[] password) throws AuthenticationException {}
+  default void authenticateSession(SessionInformation information, String username, byte[] password)
+      throws AuthenticationException {}
 
   void newSession(UUID sessionIndex, SessionInformation information);
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/feature/ProfileFeature.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/feature/ProfileFeature.java
@@ -40,6 +40,9 @@ public abstract class ProfileFeature implements Feature {
    * @param ownerProfile the {@link Profile} that owns the function.
    */
   public ProfileFeature(Profile ownerProfile) {
+    if (ownerProfile == null) {
+      throw new IllegalArgumentException("need non-null profile");
+    }
     profile = ownerProfile;
   }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientCoreProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientCoreProfile.java
@@ -55,21 +55,21 @@ public class ClientCoreProfile implements Profile {
     features = new ArrayList<>();
     eventHandler = handler;
 
-    features.add(new AuthorizeFeature(null));
-    features.add(new BootNotificationFeature(null));
+    features.add(new AuthorizeFeature(this));
+    features.add(new BootNotificationFeature(this));
     features.add(new ChangeAvailabilityFeature(this));
     features.add(new ChangeConfigurationFeature(this));
     features.add(new ClearCacheFeature(this));
     features.add(new DataTransferFeature(this));
     features.add(new GetConfigurationFeature(this));
-    features.add(new HeartbeatFeature(null));
-    features.add(new MeterValuesFeature(null));
+    features.add(new HeartbeatFeature(this));
+    features.add(new MeterValuesFeature(this));
     features.add(new RemoteStartTransactionFeature(this));
     features.add(new RemoteStopTransactionFeature(this));
     features.add(new ResetFeature(this));
-    features.add(new StartTransactionFeature(null));
-    features.add(new StatusNotificationFeature(null));
-    features.add(new StopTransactionFeature(null));
+    features.add(new StartTransactionFeature(this));
+    features.add(new StatusNotificationFeature(this));
+    features.add(new StopTransactionFeature(this));
     features.add(new UnlockConnectorFeature(this));
   }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientFirmwareManagementProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientFirmwareManagementProfile.java
@@ -41,8 +41,8 @@ public class ClientFirmwareManagementProfile implements Profile {
   public ClientFirmwareManagementProfile(ClientFirmwareManagementEventHandler eventHandler) {
     this.eventHandler = eventHandler;
     features = new HashSet<>();
-    features.add(new DiagnosticsStatusNotificationFeature(null));
-    features.add(new FirmwareStatusNotificationFeature(null));
+    features.add(new DiagnosticsStatusNotificationFeature(this));
+    features.add(new FirmwareStatusNotificationFeature(this));
     features.add(new GetDiagnosticsFeature(this));
     features.add(new UpdateFirmwareFeature(this));
   }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientFirmwareManagementProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ClientFirmwareManagementProfile.java
@@ -41,8 +41,6 @@ public class ClientFirmwareManagementProfile implements Profile {
   public ClientFirmwareManagementProfile(ClientFirmwareManagementEventHandler eventHandler) {
     this.eventHandler = eventHandler;
     features = new HashSet<>();
-    features.add(new DiagnosticsStatusNotificationFeature(this));
-    features.add(new FirmwareStatusNotificationFeature(this));
     features.add(new GetDiagnosticsFeature(this));
     features.add(new UpdateFirmwareFeature(this));
   }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerCoreProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerCoreProfile.java
@@ -44,20 +44,20 @@ public class ServerCoreProfile implements Profile {
     features = new HashSet<>();
     features.add(new AuthorizeFeature(this));
     features.add(new BootNotificationFeature(this));
-    features.add(new ChangeAvailabilityFeature(null));
-    features.add(new ChangeConfigurationFeature(null));
-    features.add(new ClearCacheFeature(null));
+    features.add(new ChangeAvailabilityFeature(this));
+    features.add(new ChangeConfigurationFeature(this));
+    features.add(new ClearCacheFeature(this));
     features.add(new DataTransferFeature(this));
-    features.add(new GetConfigurationFeature(null));
+    features.add(new GetConfigurationFeature(this));
     features.add(new HeartbeatFeature(this));
     features.add(new MeterValuesFeature(this));
-    features.add(new RemoteStartTransactionFeature(null));
-    features.add(new RemoteStopTransactionFeature(null));
-    features.add(new ResetFeature(null));
+    features.add(new RemoteStartTransactionFeature(this));
+    features.add(new RemoteStopTransactionFeature(this));
+    features.add(new ResetFeature(this));
     features.add(new StartTransactionFeature(this));
     features.add(new StatusNotificationFeature(this));
     features.add(new StopTransactionFeature(this));
-    features.add(new UnlockConnectorFeature(null));
+    features.add(new UnlockConnectorFeature(this));
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerFirmwareManagementProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerFirmwareManagementProfile.java
@@ -45,10 +45,8 @@ public class ServerFirmwareManagementProfile implements Profile {
   public ServerFirmwareManagementProfile(ServerFirmwareManagementEventHandler eventHandler) {
     this.eventHandler = eventHandler;
     features = new HashSet<>();
-    features.add(new GetDiagnosticsFeature(this));
     features.add(new DiagnosticsStatusNotificationFeature(this));
     features.add(new FirmwareStatusNotificationFeature(this));
-    features.add(new UpdateFirmwareFeature(this));
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerFirmwareManagementProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerFirmwareManagementProfile.java
@@ -45,10 +45,10 @@ public class ServerFirmwareManagementProfile implements Profile {
   public ServerFirmwareManagementProfile(ServerFirmwareManagementEventHandler eventHandler) {
     this.eventHandler = eventHandler;
     features = new HashSet<>();
-    features.add(new GetDiagnosticsFeature(null));
+    features.add(new GetDiagnosticsFeature(this));
     features.add(new DiagnosticsStatusNotificationFeature(this));
     features.add(new FirmwareStatusNotificationFeature(this));
-    features.add(new UpdateFirmwareFeature(null));
+    features.add(new UpdateFirmwareFeature(this));
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerLocalAuthListProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerLocalAuthListProfile.java
@@ -42,8 +42,8 @@ public class ServerLocalAuthListProfile implements Profile {
 
   public ServerLocalAuthListProfile() {
     featureList = new HashSet<>();
-    featureList.add(new GetLocalListVersionFeature(null));
-    featureList.add(new SendLocalListFeature(null));
+    featureList.add(new GetLocalListVersionFeature(this));
+    featureList.add(new SendLocalListFeature(this));
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerRemoteTriggerProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerRemoteTriggerProfile.java
@@ -46,7 +46,7 @@ public class ServerRemoteTriggerProfile implements Profile {
   public ServerRemoteTriggerProfile() {
 
     features = new HashSet<>();
-    features.add(new TriggerMessageFeature(null));
+    features.add(new TriggerMessageFeature(this));
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerReservationProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerReservationProfile.java
@@ -45,8 +45,8 @@ public class ServerReservationProfile implements Profile {
 
   public ServerReservationProfile() {
     features = new HashSet<>();
-    features.add(new ReserveNowFeature(null));
-    features.add(new CancelReservationFeature(null));
+    features.add(new ReserveNowFeature(this));
+    features.add(new CancelReservationFeature(this));
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerSmartChargingProfile.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/feature/profile/ServerSmartChargingProfile.java
@@ -45,9 +45,9 @@ public class ServerSmartChargingProfile implements Profile {
 
   public ServerSmartChargingProfile() {
     features = new HashSet<>();
-    features.add(new ClearChargingProfileFeature(null));
-    features.add(new GetCompositeScheduleFeature(null));
-    features.add(new SetChargingProfileFeature(null));
+    features.add(new ClearChargingProfileFeature(this));
+    features.add(new GetCompositeScheduleFeature(this));
+    features.add(new SetChargingProfileFeature(this));
   }
 
   @Override

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/features/basic/StatusNotificationFeature.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/features/basic/StatusNotificationFeature.java
@@ -43,8 +43,8 @@ public class StatusNotificationFeature implements Feature {
 
   @Override
   public Confirmation handleRequest(UUID sessionIndex, Request request) {
-    return handler.handleStatusNotificationRequest(sessionIndex,
-        (StatusNotificationRequest) request);
+    return handler.handleStatusNotificationRequest(
+        sessionIndex, (StatusNotificationRequest) request);
   }
 
   @Override


### PR DESCRIPTION
Changes include

1. formatting based on "./gradlew goJF"
2. occp 1.6 - in the package eu.chargetime.ocpp.feature.profile make sure every ProfileFeature gets "Profile" passed in every CTOR
3. remove cross-over of features in ClientFirmwareManagementProfile and ServerFirmwareManagementProfile, otherwise `eu.chargetime.ocpp.Server.open(...).new ListenerEvents() {...}.newSession(...).new SessionEvents() {...}.handleRequest(Request)` would fetch the wrong Profile not processing the requests correctly