### PR TITLE
Could eu.chargetime.ocpp:common:1.0.1 drop off redundant dependencies? 

### DIFF
--- a/ocpp-common/pom.xml
+++ b/ocpp-common/pom.xml
@@ -46,17 +46,7 @@
     </distributionManagement>
 
     <dependencies>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <version>2.1</version>
-        </dependency>
-        <dependency>
-          <groupId>javax.xml.soap</groupId>
-          <artifactId>javax.xml.soap-api</artifactId>
-          <version>1.4.0</version>
-        </dependency>
-        
+
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_eu.chargetime.ocpp:common:1.0.1_** introduced **_13_** dependencies. However, among them, **_4_** libraries (**_30%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
javax.activation:activation:jar:1.1:compile
javax.xml.soap:javax.xml.soap-api:jar:1.4.0:compile
javax.xml.bind:jaxb-api:jar:2.1:compile
javax.xml.stream:stax-api:jar:1.0-2:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_javax.activation:activation:jar:1.1:compile_** incorporates an incompatible license COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) V1.0 (COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) V1.0 cannot be used by the project with license MIT License), one of the redundant dependencies **_javax.xml.stream:stax-api:jar:1.0-2:compile_** incorporates an incompatible license COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) VERSION 1.0 (COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) VERSION 1.0 cannot be used by the project with license MIT License). As such, I suggest a refactoring operation for **_eu.chargetime.ocpp:common:1.0.1_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_eu.chargetime.ocpp:common:1.0.1_**’s maven tests.

Best regards