### PR TITLE
Allow listVersion 0 in SendLocalListRequest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
 allprojects {
     group = 'eu.chargetime.ocpp'
-    version = '1.0.2'
+    version = '1.1'
 }
 
 subprojects {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListRequest.java
@@ -74,8 +74,8 @@ public class SendLocalListRequest implements Request {
    * @param listVersion, the version number of the list
    */
   public void setListVersion(Integer listVersion) {
-    if (listVersion < 1) {
-      throw new PropertyConstraintException(listVersion, "listVersion must be > 0");
+    if (listVersion < 0) {
+      throw new PropertyConstraintException(listVersion, "listVersion must be >= 0");
     }
     this.listVersion = listVersion;
   }
@@ -122,7 +122,7 @@ public class SendLocalListRequest implements Request {
 
   @Override
   public boolean validate() {
-    boolean valid = listVersion != null && (listVersion >= 1) && (updateType != null);
+    boolean valid = listVersion != null && (listVersion >= 0) && (updateType != null);
 
     if (localAuthorizationList != null) {
       for (AuthorizationData data : localAuthorizationList) {

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/localauthlist/test/SendLocalListRequestTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/localauthlist/test/SendLocalListRequestTest.java
@@ -38,19 +38,14 @@ public class SendLocalListRequestTest {
 
   @Test
   public void setListVersion_asNegative_throwsPropertyConstraintException() {
-    testInvalidListVersion(-20);
-  }
-
-  @Test
-  public void setListVersion_asZero_throwsPropertyConstraintException() {
-    testInvalidListVersion(0);
+    testInvalidListVersion(-1);
   }
 
   private void testInvalidListVersion(int invalidVersion) {
     thrownException.expect(instanceOf(PropertyConstraintException.class));
     thrownException.expectMessage(
         equalTo(
-            "Validation failed: [listVersion must be > 0]. Current Value: ["
+            "Validation failed: [listVersion must be >= 0]. Current Value: ["
                 + invalidVersion
                 + "]"));
 
@@ -58,8 +53,8 @@ public class SendLocalListRequestTest {
   }
 
   @Test
-  public void setListVersion_isNonZeroPostive_isCorrect() {
-    for (int i = 1; i <= 10; i++) {
+  public void setListVersion_isNotNegative_isCorrect() {
+    for (int i = 0; i <= 10; i++) {
       // When
       request.setListVersion(i);
       // Then


### PR DESCRIPTION
The OCPP 1.6 specification mentions no explicit value range for the
listVersion field in the SendLocalListRequest, but specifies that 0
should be returned as the version in case the list is empty. Now there
is no message to clear the local authorization list, so clearing the
list can only be achieved with a SendLocalListRequest with an empty
list, and that is a use case for listVersion 0. In fact the OCPP
certification test tool employs such requests.

Change SendLocalListRequest to allow listVersion 0 rather than only 1 or
higher, and adapt the unit test accordingly.

While at it, bump the version in build.gradle to "1.1" to match the one
from pom.xml.