### PR TITLE
Use key when checking if session is in the Map.

### DIFF
--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
@@ -171,7 +171,7 @@ public class Server {
   }
 
   private Optional<UUID> getSessionID(ISession session) {
-    if (!sessions.containsValue(session)) {
+    if (!sessions.containsKey(session.getSessionId())) {
       return Optional.empty();
     }
 


### PR DESCRIPTION
Fixes ChargeTimeEU/Java-OCA-OCPP#208. We already have session ID in `session` object, and can use it to make sure session is still in the `Map` keys. There is no need to check if the `session` object itself is in the `Map` values.