### PR TITLE
Add ConfirmationCompletedHandler

### DIFF
--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
@@ -2,6 +2,7 @@ package eu.chargetime.ocpp;
 /*
 ChargeTime.eu - Java-OCA-OCPP
 Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 MIT License
 
@@ -203,6 +204,16 @@ public abstract class Communicator {
   public void sendCallResult(String uniqueId, String action, Confirmation confirmation) {
     try {
       radio.send(makeCallResult(uniqueId, action, packPayload(confirmation)));
+
+      ConfirmationCompletedHandler completedHandler = confirmation.getCompletedHandler();
+
+      if (completedHandler != null) {
+        try {
+          completedHandler.onConfirmationCompleted();
+        } catch (Throwable e) {
+          events.onError(uniqueId, "ConfirmationCompletedHandlerFailed", "The confirmation completed callback handler failed with exception " + e.toString(), confirmation);
+        }
+      }
     } catch (NotConnectedException ex) {
       logger.warn("sendCallResult() failed", ex);
       events.onError(

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/ConfirmationCompletedHandler.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/ConfirmationCompletedHandler.java
@@ -2,11 +2,9 @@ package eu.chargetime.ocpp.model;
 
 /*
 ChargeTime.eu - Java-OCA-OCPP
-Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
 
 MIT License
 
-Copyright (C) 2016-2018 Thomas Volden
 Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -28,15 +26,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-/** Interface used to flag a Model as a Confirmation payload. */
-public abstract class Confirmation implements Validatable {
-    private transient ConfirmationCompletedHandler completedHandler;
 
-    public ConfirmationCompletedHandler getCompletedHandler() {
-        return completedHandler;
-    }
-    public void setCompletedHandler(ConfirmationCompletedHandler completedHandler) {
-        this.completedHandler = completedHandler;
-    }
+/**
+ * Callback that can perform actions after the confirmation is sent back to the Charge Point
+ */
+public interface ConfirmationCompletedHandler {
+    void onConfirmationCompleted();
 }
-

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/TestConfirmation.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/TestConfirmation.java
@@ -7,6 +7,7 @@ Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
 MIT License
 
 Copyright (C) 2016-2018 Thomas Volden
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +29,7 @@ SOFTWARE.
 */
 
 /** Test implementation of the Confirmation interface. Used for tests. */
-public class TestConfirmation implements Confirmation {
+public class TestConfirmation extends Confirmation {
   @Override
   public boolean validate() {
     return true;

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/CommunicatorTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/CommunicatorTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 import eu.chargetime.ocpp.*;
+import eu.chargetime.ocpp.model.Confirmation;
+import eu.chargetime.ocpp.model.ConfirmationCompletedHandler;
 import eu.chargetime.ocpp.model.Message;
 import eu.chargetime.ocpp.model.Request;
 import org.junit.Before;
@@ -18,6 +20,7 @@ import org.mockito.runners.MockitoJUnitRunner;
    MIT License
 
    Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -194,5 +197,44 @@ public class CommunicatorTest {
 
     // Then
     verify(receiver, times(3)).send(eq(uniqueId));
+  }
+
+  @Test
+  public void confirmationCallback_Handler() {
+    // Given
+    Confirmation conf = new Confirmation() {
+      @Override
+      public boolean validate() {
+        return true;
+      }
+    };
+
+    ConfirmationCompletedHandler handler = mock(ConfirmationCompletedHandler.class);
+    conf.setCompletedHandler(handler);
+
+    String uniqueId = "some id";
+    String action = "some action";
+
+    // When
+    communicator.sendCallResult(uniqueId, action, conf);
+
+    // Then
+    verify(handler, times(1)).onConfirmationCompleted();
+  }
+
+  @Test
+  public void confirmationCallback_noHandler() {
+    // Make sure it's not crashing because it has no handler set
+
+    Confirmation conf = new Confirmation() {
+      @Override
+      public boolean validate() {
+        return true;
+      }
+    };
+
+    String uniqueId = "some id";
+    String action = "some action";
+    communicator.sendCallResult(uniqueId, action, conf);
   }
 }

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
@@ -24,6 +24,7 @@ Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
 MIT License
 
 Copyright (C) 2016-2018 Thomas Volden
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -119,7 +120,12 @@ public class SessionTest {
   @Test
   public void sendConfirmation_sendsConfirmationToCommunicator() {
     // Given
-    Confirmation conf = () -> false;
+    Confirmation conf = new Confirmation() {
+      @Override
+      public boolean validate() {
+        return false;
+      }
+    };
     String someUniqueId = "Some id";
     String action = "Some action";
 
@@ -162,7 +168,13 @@ public class SessionTest {
   public void onCall_handledCallback_callSendCallResult() throws Exception {
     // Given
     String someId = "Some id";
-    Confirmation aConfirmation = () -> true;
+    Confirmation aConfirmation = new Confirmation() {
+      @Override
+      public boolean validate() {
+        return false;
+      }
+    };
+
     doAnswer(
             invocation ->
                 invocation.getArgumentAt(0, CompletableFuture.class).complete(aConfirmation))

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/AuthorizeConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/AuthorizeConfirmation.java
@@ -4,6 +4,7 @@ package eu.chargetime.ocpp.model.core;
 ChargeTime.eu - Java-OCA-OCPP
 Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
 Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 MIT License
 
@@ -37,7 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point in response to a {@link AuthorizeRequest}. */
 @XmlRootElement(name = "authorizeResponse")
-public class AuthorizeConfirmation implements Confirmation {
+public class AuthorizeConfirmation extends Confirmation {
 
   private IdTagInfo idTagInfo;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
@@ -4,6 +4,7 @@ package eu.chargetime.ocpp.model.core;
 ChargeTime.eu - Java-OCA-OCPP
 Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
 Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 MIT License
 
@@ -45,7 +46,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "bootNotificationResponse")
 @XmlType(propOrder = {"status", "currentTime", "interval"})
-public class BootNotificationConfirmation implements Confirmation {
+public class BootNotificationConfirmation extends Confirmation {
 
   private ZonedDateTime currentTime;
   private Integer interval;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityConfirmation.java
@@ -9,6 +9,7 @@ MIT License
 
 Copyright (C) 2016-2018 Thomas Volden
 Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** return by Charge Point to Central System. */
 @XmlRootElement(name = "changeAvailabilityResponse")
-public class ChangeAvailabilityConfirmation implements Confirmation {
+public class ChangeAvailabilityConfirmation extends Confirmation {
 
   private AvailabilityStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeConfigurationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeConfigurationConfirmation.java
@@ -9,6 +9,7 @@ MIT License
 
 Copyright (C) 2016-2018 Thomas Volden
 Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Returned from Charge Point to Central System */
 @XmlRootElement(name = "changeConfigurationResponse")
-public class ChangeConfigurationConfirmation implements Confirmation {
+public class ChangeConfigurationConfirmation extends Confirmation {
 
   private ConfigurationStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ClearCacheConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ClearCacheConfirmation.java
@@ -9,6 +9,7 @@ MIT License
 
 Copyright (C) 2016-2018 Thomas Volden
 Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System in response to a {@link ClearCacheRequest}. */
 @XmlRootElement(name = "clearCacheResponse")
-public class ClearCacheConfirmation implements Confirmation {
+public class ClearCacheConfirmation extends Confirmation {
 
   private ClearCacheStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/DataTransferConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/DataTransferConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.core;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,7 +41,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "dataTransferResponse")
 @XmlType(propOrder = {"status", "data"})
-public class DataTransferConfirmation implements Confirmation {
+public class DataTransferConfirmation extends Confirmation {
 
   private DataTransferStatus status;
   private String data;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/GetConfigurationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/GetConfigurationConfirmation.java
@@ -17,6 +17,7 @@ Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
 MIT License
 
 Copyright (C) 2016-2018 Thomas Volden
+Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +43,7 @@ SOFTWARE.
  */
 @XmlRootElement(name = "getConfigurationResponse")
 @XmlType(propOrder = {"configurationKey", "unknownKey"})
-public class GetConfigurationConfirmation implements Confirmation {
+public class GetConfigurationConfirmation extends Confirmation {
 
   private static final String ERROR_MESSAGE = "Exceeds limit of %s chars";
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/HeartbeatConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/HeartbeatConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.core;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point in response to a {@link HeartbeatRequest}. */
 @XmlRootElement(name = "heartbeatResponse")
-public class HeartbeatConfirmation implements Confirmation {
+public class HeartbeatConfirmation extends Confirmation {
   private ZonedDateTime currentTime;
 
   /**

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.core;
  * MIT License
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +34,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** */
 @XmlRootElement(name = "meterValuesResponse")
-public class MeterValuesConfirmation implements Confirmation {
+public class MeterValuesConfirmation extends Confirmation {
   @Override
   public boolean validate() {
     return true;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStartTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStartTransactionConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.core;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent from Charge Point to Central System. */
 @XmlRootElement(name = "remoteStartTransactionResponse")
-public class RemoteStartTransactionConfirmation implements Confirmation {
+public class RemoteStartTransactionConfirmation extends Confirmation {
   private RemoteStartStopStatus status;
 
   /**

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStopTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStopTransactionConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.core;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** sent from Charge Point to Central System. */
 @XmlRootElement(name = "remoteStopTransactionResponse")
-public class RemoteStopTransactionConfirmation implements Confirmation {
+public class RemoteStopTransactionConfirmation extends Confirmation {
 
   private RemoteStartStopStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ResetConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ResetConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.core;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System in response to a {@link ResetRequest}. */
 @XmlRootElement
-public class ResetConfirmation implements Confirmation {
+public class ResetConfirmation extends Confirmation {
 
   private ResetStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.core;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +40,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "startTransactionResponse")
 @XmlType(propOrder = {"transactionId", "idTagInfo"})
-public class StartTransactionConfirmation implements Confirmation {
+public class StartTransactionConfirmation extends Confirmation {
 
   private IdTagInfo idTagInfo;
   private Integer transactionId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StatusNotificationConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.core;
  * MIT License
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import java.util.Objects;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "statusNotificationResponse")
-public class StatusNotificationConfirmation implements Confirmation {
+public class StatusNotificationConfirmation extends Confirmation {
   @Override
   public boolean validate() {
     return true;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.core;
  * MIT License
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * Sent by the Central System to the Charge Point in response to a {@link StopTransactionRequest}.
  */
 @XmlRootElement(name = "stopTransactionResponse")
-public class StopTransactionConfirmation implements Confirmation {
+public class StopTransactionConfirmation extends Confirmation {
   private IdTagInfo idTagInfo;
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/UnlockConnectorConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/UnlockConnectorConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.core;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * Sent by the Charge Point to the Central System in response to an {@link UnlockConnectorRequest}.
  */
 @XmlRootElement(name = "unlockConnectorResponse")
-public class UnlockConnectorConfirmation implements Confirmation {
+public class UnlockConnectorConfirmation extends Confirmation {
 
   private UnlockStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/DiagnosticsStatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/DiagnosticsStatusNotificationConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.firmware;
  *
  * Copyright (C) 2016 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2018 Mikhail Kladkevich <kladmv@ecp-share.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * DiagnosticsStatusNotificationRequest}.
  */
 @XmlRootElement(name = "diagnosticsStatusNotificationResponse")
-public class DiagnosticsStatusNotificationConfirmation implements Confirmation {
+public class DiagnosticsStatusNotificationConfirmation extends Confirmation {
 
   public DiagnosticsStatusNotificationConfirmation() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/FirmwareStatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/FirmwareStatusNotificationConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.firmware;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2018 Mikhail Kladkevich <kladmv@ecp-share.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * FirmwareStatusNotificationRequest}.
  */
 @XmlRootElement(name = "firmwareStatusNotificationResponse")
-public class FirmwareStatusNotificationConfirmation implements Confirmation {
+public class FirmwareStatusNotificationConfirmation extends Confirmation {
 
   public FirmwareStatusNotificationConfirmation() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsConfirmation.java
@@ -5,6 +5,7 @@ package eu.chargetime.ocpp.model.firmware;
    MIT License
 
    Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +35,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "getDiagnosticsResponse")
-public class GetDiagnosticsConfirmation implements Confirmation {
+public class GetDiagnosticsConfirmation extends Confirmation {
   private String fileName;
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.firmware;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2018 Mikhail Kladkevich <kladmv@ecp-share.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * Sent by the Charge Point to the Central System in response to an {@link UpdateFirmwareRequest}.
  */
 @XmlRootElement(name = "updateFirmwareResponse")
-public class UpdateFirmwareConfirmation implements Confirmation {
+public class UpdateFirmwareConfirmation extends Confirmation {
 
   public UpdateFirmwareConfirmation() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/GetLocalListVersionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/GetLocalListVersionConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.localauthlist;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
-public class GetLocalListVersionConfirmation implements Confirmation {
+public class GetLocalListVersionConfirmation extends Confirmation {
 
   private Integer listVersion = -2;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.localauthlist;
  *
  * Copyright (C) 2016-2018 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
-public class SendLocalListConfirmation implements Confirmation {
+public class SendLocalListConfirmation extends Confirmation {
 
   private UpdateStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/remotetrigger/TriggerMessageConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/remotetrigger/TriggerMessageConfirmation.java
@@ -2,12 +2,12 @@ package eu.chargetime.ocpp.model.remotetrigger;
 
 /*
 ChargeTime.eu - Java-OCA-OCPP
-Copyright (C) 2017 Emil Christopher Solli Melar <emil@iconsultable.no>
+Copyright (C) 2022 Emil Christopher Solli Melar <emil@iconsultable.no>
 Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
 
 MIT License
 
-Copyright (C) 2017 Emil Christopher Solli Melar
+Copyright (C) 2022 Emil Christopher Solli Melar
 Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "triggerMessageResponse")
-public class TriggerMessageConfirmation implements Confirmation {
+public class TriggerMessageConfirmation extends Confirmation {
 
   private TriggerMessageStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/CancelReservationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/CancelReservationConfirmation.java
@@ -8,6 +8,7 @@ package eu.chargetime.ocpp.model.reservation;
  * Copyright (C) 2016 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2018 Mikhail Kladkevich <kladmv@ecp-share.com>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +40,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * CancelReservationRequest}.
  */
 @XmlRootElement(name = "cancelReservationResponse")
-public class CancelReservationConfirmation implements Confirmation {
+public class CancelReservationConfirmation extends Confirmation {
 
   private CancelReservationStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/ReserveNowConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/ReserveNowConfirmation.java
@@ -8,6 +8,7 @@ package eu.chargetime.ocpp.model.reservation;
  * Copyright (C) 2016 Thomas Volden <tv@chargetime.eu>
  * Copyright (C) 2018 Mikhail Kladkevich <kladmv@ecp-share.com>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System in response to an {@link ReserveNowRequest}. */
 @XmlRootElement(name = "reserveNowResponse")
-public class ReserveNowConfirmation implements Confirmation {
+public class ReserveNowConfirmation extends Confirmation {
 
   private ReservationStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/CertificateSignedConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/CertificateSignedConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class CertificateSignedConfirmation implements Confirmation {
+public class CertificateSignedConfirmation extends Confirmation {
 
   private CertificateSignedStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/DeleteCertificateConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/DeleteCertificateConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class DeleteCertificateConfirmation implements Confirmation {
+public class DeleteCertificateConfirmation extends Confirmation {
 
   private DeleteCertificateStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/ExtendedTriggerMessageConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/ExtendedTriggerMessageConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class ExtendedTriggerMessageConfirmation implements Confirmation {
+public class ExtendedTriggerMessageConfirmation extends Confirmation {
 
   private TriggerMessageStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetInstalledCertificateIdsConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetInstalledCertificateIdsConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +35,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class GetInstalledCertificateIdsConfirmation implements Confirmation {
+public class GetInstalledCertificateIdsConfirmation extends Confirmation {
 
   private GetInstalledCertificateStatusEnumType status;
   private CertificateHashDataType[] certificateHashData;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetLogConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetLogConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +36,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class GetLogConfirmation implements Confirmation {
+public class GetLogConfirmation extends Confirmation {
 
   private static final transient Validator filenameValidator =
     new ValidatorBuilder()

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/InstallCertificateConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/InstallCertificateConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class InstallCertificateConfirmation implements Confirmation {
+public class InstallCertificateConfirmation extends Confirmation {
 
   private CertificateStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/LogStatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/LogStatusNotificationConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class LogStatusNotificationConfirmation implements Confirmation {
+public class LogStatusNotificationConfirmation extends Confirmation {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SecurityEventNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SecurityEventNotificationConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SecurityEventNotificationConfirmation implements Confirmation {
+public class SecurityEventNotificationConfirmation extends Confirmation {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignCertificateConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignCertificateConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignCertificateConfirmation implements Confirmation {
+public class SignCertificateConfirmation extends Confirmation {
 
   private GenericStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedFirmwareStatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedFirmwareStatusNotificationConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignedFirmwareStatusNotificationConfirmation implements Confirmation {
+public class SignedFirmwareStatusNotificationConfirmation extends Confirmation {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedUpdateFirmwareConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedUpdateFirmwareConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.securityext;
    MIT License
 
    Copyright (C) 2022 Mathias Oben <mathias.oben@enervalis.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignedUpdateFirmwareConfirmation implements Confirmation {
+public class SignedUpdateFirmwareConfirmation extends Confirmation {
 
   private UpdateFirmwareStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ClearChargingProfileConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ClearChargingProfileConfirmation.java
@@ -8,6 +8,7 @@ package eu.chargetime.ocpp.model.smartcharging;
  * Copyright (C) 2018 Fabian Röhr <fabian.roehr@netlight.com>
  * Copyright (C) 2018 Robin Roscher <r.roscher@ee-mobility.com>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +36,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "clearChargingProfileResponse")
-public class ClearChargingProfileConfirmation implements Confirmation {
+public class ClearChargingProfileConfirmation extends Confirmation {
 
   private ClearChargingProfileStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/GetCompositeScheduleConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/GetCompositeScheduleConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.smartcharging;
    MIT License
 
    Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +34,7 @@ import java.time.ZonedDateTime;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
 
-public class GetCompositeScheduleConfirmation implements Confirmation {
+public class GetCompositeScheduleConfirmation extends Confirmation {
 
   private GetCompositeScheduleStatus status;
   private Integer connectorId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileConfirmation.java
@@ -7,6 +7,7 @@ package eu.chargetime.ocpp.model.smartcharging;
  *
  * Copyright (C) 2017 Emil Christopher Solli Melar <emil@iconsultable.no>
  * Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+ * Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +35,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "setChargingProfileResponse")
-public class SetChargingProfileConfirmation implements Confirmation {
+public class SetChargingProfileConfirmation extends Confirmation {
 
   private ChargingProfileStatus status;
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/BootNotificationConfirmation.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/BootNotificationConfirmation.java
@@ -6,6 +6,7 @@ package eu.chargetime.ocpp.model.basic;
 
    Copyright (C) 2018 Thomas Volden <tv@chargetime.eu>
    Copyright (C) 2019 Kevin Raddatz <kevin.raddatz@valtech-mobility.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +35,7 @@ import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /** sent by the CSMS to the Charging Station in response to a {@link BootNotificationRequest}. */
-public class BootNotificationConfirmation implements Confirmation {
+public class BootNotificationConfirmation extends Confirmation {
   private transient RequiredValidator validator = new RequiredValidator();
 
   private ZonedDateTime currentTime;

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/GetVariablesConfirmation.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/GetVariablesConfirmation.java
@@ -5,6 +5,7 @@ package eu.chargetime.ocpp.model.basic;
    MIT License
 
    Copyright (C) 2018 Thomas Volden <tv@chargetime.eu>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class GetVariablesConfirmation implements Confirmation {
+public class GetVariablesConfirmation extends Confirmation {
 
   private GetVariableResultType[] getVariableResult;
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/SetVariablesConfirmation.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/SetVariablesConfirmation.java
@@ -5,6 +5,7 @@ package eu.chargetime.ocpp.model.basic;
    MIT License
 
    Copyright (C) 2018 Thomas Volden <tv@chargetime.eu>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +38,7 @@ import java.util.Objects;
  * This contains the field definition of the SetVariablesResponse PDU sent by the Charging Station
  * to the CSMS in response to a SetVariablesRequest.
  */
-public class SetVariablesConfirmation implements Confirmation {
+public class SetVariablesConfirmation extends Confirmation {
   private transient Validator<Object> requiredValidator = new RequiredValidator();
 
   private SetVariableResultType[] setVariableResult;

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/StatusNotificationConfirmation.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/StatusNotificationConfirmation.java
@@ -5,6 +5,7 @@ package eu.chargetime.ocpp.model.basic;
    MIT License
 
    Copyright (C) 2021 John Michael Luy <johnmichael.luy@gmail.com>
+   Copyright (C) 2022 Emil Melar <emil@iconsultable.no>
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +30,7 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
-public class StatusNotificationConfirmation implements Confirmation {
+public class StatusNotificationConfirmation extends Confirmation {
 
   @Override
   public boolean validate() {


### PR DESCRIPTION
Add a handler on each Confirmation perform actions after a confirmations are sent back to the Charge Point.
This is to send configuration variables etc after the BootNotification is confirmed from the server. Some CPs don't accept configs before the confirmation on BootNotification is returned. 
This makes it possible within the synchronous nature of the handlers.