### PR TITLE
Propagate code and reason from disconnect from server on client

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketReceiver.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketReceiver.java
@@ -37,7 +37,7 @@ public class WebSocketReceiver implements Receiver {
   @Override
   public void disconnect() {
     receiverEvents.close();
-    handler.disconnected();
+    handler.disconnected(0, "disconnect() method called");
   }
 
   void relay(String message) {

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
@@ -105,7 +105,7 @@ public class WebSocketTransmitter implements Transmitter {
             logger.debug(
                 "On connection close (code: {}, reason: {}, remote: {})", code, reason, remote);
 
-            events.disconnected();
+            events.disconnected(code, reason);
           }
 
           @Override

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Client.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Client.java
@@ -113,8 +113,8 @@ public class Client {
           }
 
           @Override
-          public void handleConnectionClosed() {
-            if (events != null) events.connectionClosed();
+          public void handleConnectionClosed(int code, String reason) {
+            if (events != null) events.connectionClosed(code, reason);
           }
 
           @Override

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ClientEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ClientEvents.java
@@ -30,5 +30,5 @@ SOFTWARE.
 public interface ClientEvents {
   void connectionOpened();
 
-  void connectionClosed();
+  void connectionClosed(int code, String reason);
 }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
@@ -203,6 +203,16 @@ public abstract class Communicator {
   public void sendCallResult(String uniqueId, String action, Confirmation confirmation) {
     try {
       radio.send(makeCallResult(uniqueId, action, packPayload(confirmation)));
+
+      ConfirmationCompletedHandler completedHandler = confirmation.getCompletedHandler();
+
+      if (completedHandler != null) {
+        try {
+          completedHandler.onConfirmationCompleted();
+        } catch (Throwable e) {
+          events.onError(uniqueId, "ConfirmationCompletedHandlerFailed", "The confirmation completed callback handler failed with exception " + e.toString(), confirmation);
+        }
+      }
     } catch (NotConnectedException ex) {
       logger.warn("sendCallResult() failed", ex);
       events.onError(

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Communicator.java
@@ -302,8 +302,8 @@ public abstract class Communicator {
     }
 
     @Override
-    public void disconnected() {
-      events.onDisconnected();
+    public void disconnected(int code, String reason) {
+      events.onDisconnected(code, reason);
     }
   }
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/CommunicatorEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/CommunicatorEvents.java
@@ -66,8 +66,10 @@ public interface CommunicatorEvents {
    */
   void onError(String id, String errorCode, String errorDescription, Object payload);
 
-  /** The connection was disconnected. */
-  void onDisconnected();
+  /** The connection was disconnected.
+   * @param code
+   * @param reason*/
+  void onDisconnected(int code, String reason);
 
   /** A connection was established. */
   void onConnected();

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/RadioEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/RadioEvents.java
@@ -39,6 +39,8 @@ public interface RadioEvents {
    */
   void receivedMessage(Object message);
 
-  /** Disconnected from node. */
-  void disconnected();
+  /** Disconnected from node.
+   * @param code
+   * @param reason*/
+  void disconnected(int code, String reason);
 }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
@@ -143,7 +143,7 @@ public class Server {
                   }
 
                   @Override
-                  public void handleConnectionClosed() {
+                  public void handleConnectionClosed(int code, String reason) {
                     Optional<UUID> sessionIdOptional = getSessionID(session);
                     if (sessionIdOptional.isPresent()) {
                       serverEvents.lostSession(sessionIdOptional.get());

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java
@@ -221,8 +221,8 @@ public class Session implements ISession {
     }
 
     @Override
-    public void onDisconnected() {
-      events.handleConnectionClosed();
+    public void onDisconnected(int code, String reason) {
+      events.handleConnectionClosed(code, reason);
     }
 
     @Override

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/SessionEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/SessionEvents.java
@@ -59,8 +59,10 @@ public interface SessionEvents {
    */
   void handleError(String uniqueId, String errorCode, String errorDescription, Object payload);
 
-  /** Handle a closed connection. */
-  void handleConnectionClosed();
+  /** Handle a closed connection.
+   * @param code
+   * @param reason*/
+  void handleConnectionClosed(int code, String reason);
 
   /** Handle a opened connection. */
   void handleConnectionOpened();

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/Confirmation.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/Confirmation.java
@@ -28,4 +28,14 @@ SOFTWARE.
 */
 
 /** Interface used to flag a Model as a Confirmation payload. */
-public interface Confirmation extends Validatable {}
+public abstract class Confirmation implements Validatable {
+    private transient ConfirmationCompletedHandler completedHandler;
+
+    public ConfirmationCompletedHandler getCompletedHandler() {
+        return completedHandler;
+    }
+    public void setCompletedHandler(ConfirmationCompletedHandler completedHandler) {
+        this.completedHandler = completedHandler;
+    }
+}
+

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/ConfirmationCompletedHandler.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/ConfirmationCompletedHandler.java
@@ -2,11 +2,11 @@ package eu.chargetime.ocpp.model;
 
 /*
 ChargeTime.eu - Java-OCA-OCPP
-Copyright (C) 2015-2016 Thomas Volden <tv@chargetime.eu>
+Copyright (C) 2015-2022 Thomas Volden <tv@chargetime.eu>
 
 MIT License
 
-Copyright (C) 2016-2018 Thomas Volden
+Copyright (C) 2016-2022 Thomas Volden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -27,10 +27,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-/** Test implementation of the Confirmation interface. Used for tests. */
-public class TestConfirmation extends Confirmation {
-  @Override
-  public boolean validate() {
-    return true;
-  }
+
+/**
+ * Callback that can perform actions after the confirmation is sent back to the Charge Point
+ */
+public interface ConfirmationCompletedHandler {
+    void onConfirmationCompleted();
 }

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ClientTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ClientTest.java
@@ -89,7 +89,7 @@ public class ClientTest {
 
     // Then
     verify(events, times(1)).connectionOpened();
-    verify(events, never()).connectionClosed();
+    verify(events, never()).connectionClosed(0, null);
   }
 
   @Test
@@ -98,10 +98,10 @@ public class ClientTest {
     client.connect(null, events);
 
     // When
-    this.eventHandler.handleConnectionClosed();
+    this.eventHandler.handleConnectionClosed(0, null);
 
     // Then
-    verify(events, times(1)).connectionClosed();
+    verify(events, times(1)).connectionClosed(0, null);
     verify(events, never()).connectionOpened();
   }
 

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/CommunicatorTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/CommunicatorTest.java
@@ -4,6 +4,8 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
 import eu.chargetime.ocpp.*;
+import eu.chargetime.ocpp.model.Confirmation;
+import eu.chargetime.ocpp.model.ConfirmationCompletedHandler;
 import eu.chargetime.ocpp.model.Message;
 import eu.chargetime.ocpp.model.Request;
 import org.junit.Before;
@@ -194,5 +196,44 @@ public class CommunicatorTest {
 
     // Then
     verify(receiver, times(3)).send(eq(uniqueId));
+  }
+
+  @Test
+  public void confirmationCallback_Handler() {
+    // Given
+    Confirmation conf = new Confirmation() {
+      @Override
+      public boolean validate() {
+        return true;
+      }
+    };
+
+    ConfirmationCompletedHandler handler = mock(ConfirmationCompletedHandler.class);
+    conf.setCompletedHandler(handler);
+
+    String uniqueId = "some id";
+    String action = "some action";
+
+    // When
+    communicator.sendCallResult(uniqueId, action, conf);
+
+    // Then
+    verify(handler, times(1)).onConfirmationCompleted();
+  }
+
+  @Test
+  public void confirmationCallback_noHandler() {
+    // Make sure it's not crashing because it has no handler set
+
+    Confirmation conf = new Confirmation() {
+      @Override
+      public boolean validate() {
+        return true;
+      }
+    };
+
+    String uniqueId = "some id";
+    String action = "some action";
+    communicator.sendCallResult(uniqueId, action, conf);
   }
 }

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
@@ -119,7 +119,12 @@ public class SessionTest {
   @Test
   public void sendConfirmation_sendsConfirmationToCommunicator() {
     // Given
-    Confirmation conf = () -> false;
+    Confirmation conf = new Confirmation() {
+      @Override
+      public boolean validate() {
+        return false;
+      }
+    };
     String someUniqueId = "Some id";
     String action = "Some action";
 
@@ -162,7 +167,13 @@ public class SessionTest {
   public void onCall_handledCallback_callSendCallResult() throws Exception {
     // Given
     String someId = "Some id";
-    Confirmation aConfirmation = () -> true;
+    Confirmation aConfirmation = new Confirmation() {
+      @Override
+      public boolean validate() {
+        return false;
+      }
+    };
+
     doAnswer(
             invocation ->
                 invocation.getArgumentAt(0, CompletableFuture.class).complete(aConfirmation))

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/FakeChargePoint.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/FakeChargePoint.java
@@ -307,7 +307,7 @@ public class FakeChargePoint {
             public void connectionOpened() {}
 
             @Override
-            public void connectionClosed() {}
+            public void connectionClosed(int code, String reason) {}
           });
     } catch (Exception ex) {
       ex.printStackTrace();

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/TimeoutSessionDecorator.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/TimeoutSessionDecorator.java
@@ -123,8 +123,8 @@ public class TimeoutSessionDecorator implements ISession {
       }
 
       @Override
-      public void handleConnectionClosed() {
-        eventHandler.handleConnectionClosed();
+      public void handleConnectionClosed(int code, String reason) {
+        eventHandler.handleConnectionClosed(code, reason);
         stopTimer();
       }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceReceiver.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceReceiver.java
@@ -57,7 +57,7 @@ public class WebServiceReceiver extends SOAPSyncHelper implements Receiver {
         logger.info("disconnect() failed", e);
       }
     }
-    events.disconnected();
+    events.disconnected(0, "disconnect() method called");
     receiverEvents.disconnect();
   }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceTransmitter.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/WebServiceTransmitter.java
@@ -55,7 +55,7 @@ public class WebServiceTransmitter extends SOAPSyncHelper implements Transmitter
         logger.info("disconnect() failed", e);
       }
     }
-    events.disconnected();
+    events.disconnected(0, "disconnect() method called");
   }
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/AuthorizeConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/AuthorizeConfirmation.java
@@ -37,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point in response to a {@link AuthorizeRequest}. */
 @XmlRootElement(name = "authorizeResponse")
-public class AuthorizeConfirmation implements Confirmation {
+public class AuthorizeConfirmation extends Confirmation {
 
   private IdTagInfo idTagInfo;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationConfirmation.java
@@ -45,7 +45,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "bootNotificationResponse")
 @XmlType(propOrder = {"status", "currentTime", "interval"})
-public class BootNotificationConfirmation implements Confirmation {
+public class BootNotificationConfirmation extends Confirmation {
 
   private ZonedDateTime currentTime;
   private Integer interval;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityConfirmation.java
@@ -37,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** return by Charge Point to Central System. */
 @XmlRootElement(name = "changeAvailabilityResponse")
-public class ChangeAvailabilityConfirmation implements Confirmation {
+public class ChangeAvailabilityConfirmation extends Confirmation {
 
   private AvailabilityStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeConfigurationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeConfigurationConfirmation.java
@@ -37,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Returned from Charge Point to Central System */
 @XmlRootElement(name = "changeConfigurationResponse")
-public class ChangeConfigurationConfirmation implements Confirmation {
+public class ChangeConfigurationConfirmation extends Confirmation {
 
   private ConfigurationStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ClearCacheConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ClearCacheConfirmation.java
@@ -37,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System in response to a {@link ClearCacheRequest}. */
 @XmlRootElement(name = "clearCacheResponse")
-public class ClearCacheConfirmation implements Confirmation {
+public class ClearCacheConfirmation extends Confirmation {
 
   private ClearCacheStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/DataTransferConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/DataTransferConfirmation.java
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "dataTransferResponse")
 @XmlType(propOrder = {"status", "data"})
-public class DataTransferConfirmation implements Confirmation {
+public class DataTransferConfirmation extends Confirmation {
 
   private DataTransferStatus status;
   private String data;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/GetConfigurationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/GetConfigurationConfirmation.java
@@ -42,7 +42,7 @@ SOFTWARE.
  */
 @XmlRootElement(name = "getConfigurationResponse")
 @XmlType(propOrder = {"configurationKey", "unknownKey"})
-public class GetConfigurationConfirmation implements Confirmation {
+public class GetConfigurationConfirmation extends Confirmation {
 
   private static final String ERROR_MESSAGE = "Exceeds limit of %s chars";
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/HeartbeatConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/HeartbeatConfirmation.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point in response to a {@link HeartbeatRequest}. */
 @XmlRootElement(name = "heartbeatResponse")
-public class HeartbeatConfirmation implements Confirmation {
+public class HeartbeatConfirmation extends Confirmation {
   private ZonedDateTime currentTime;
 
   /**

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesConfirmation.java
@@ -33,7 +33,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** */
 @XmlRootElement(name = "meterValuesResponse")
-public class MeterValuesConfirmation implements Confirmation {
+public class MeterValuesConfirmation extends Confirmation {
   @Override
   public boolean validate() {
     return true;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStartTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStartTransactionConfirmation.java
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent from Charge Point to Central System. */
 @XmlRootElement(name = "remoteStartTransactionResponse")
-public class RemoteStartTransactionConfirmation implements Confirmation {
+public class RemoteStartTransactionConfirmation extends Confirmation {
   private RemoteStartStopStatus status;
 
   /**

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStopTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStopTransactionConfirmation.java
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** sent from Charge Point to Central System. */
 @XmlRootElement(name = "remoteStopTransactionResponse")
-public class RemoteStopTransactionConfirmation implements Confirmation {
+public class RemoteStopTransactionConfirmation extends Confirmation {
 
   private RemoteStartStopStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ResetConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ResetConfirmation.java
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System in response to a {@link ResetRequest}. */
 @XmlRootElement
-public class ResetConfirmation implements Confirmation {
+public class ResetConfirmation extends Confirmation {
 
   private ResetStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionConfirmation.java
@@ -39,7 +39,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "startTransactionResponse")
 @XmlType(propOrder = {"transactionId", "idTagInfo"})
-public class StartTransactionConfirmation implements Confirmation {
+public class StartTransactionConfirmation extends Confirmation {
 
   private IdTagInfo idTagInfo;
   private Integer transactionId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StatusNotificationConfirmation.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "statusNotificationResponse")
-public class StatusNotificationConfirmation implements Confirmation {
+public class StatusNotificationConfirmation extends Confirmation {
   @Override
   public boolean validate() {
     return true;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionConfirmation.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * Sent by the Central System to the Charge Point in response to a {@link StopTransactionRequest}.
  */
 @XmlRootElement(name = "stopTransactionResponse")
-public class StopTransactionConfirmation implements Confirmation {
+public class StopTransactionConfirmation extends Confirmation {
   private IdTagInfo idTagInfo;
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/UnlockConnectorConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/UnlockConnectorConfirmation.java
@@ -37,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * Sent by the Charge Point to the Central System in response to an {@link UnlockConnectorRequest}.
  */
 @XmlRootElement(name = "unlockConnectorResponse")
-public class UnlockConnectorConfirmation implements Confirmation {
+public class UnlockConnectorConfirmation extends Confirmation {
 
   private UnlockStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/DiagnosticsStatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/DiagnosticsStatusNotificationConfirmation.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * DiagnosticsStatusNotificationRequest}.
  */
 @XmlRootElement(name = "diagnosticsStatusNotificationResponse")
-public class DiagnosticsStatusNotificationConfirmation implements Confirmation {
+public class DiagnosticsStatusNotificationConfirmation extends Confirmation {
 
   public DiagnosticsStatusNotificationConfirmation() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/FirmwareStatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/FirmwareStatusNotificationConfirmation.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * FirmwareStatusNotificationRequest}.
  */
 @XmlRootElement(name = "firmwareStatusNotificationResponse")
-public class FirmwareStatusNotificationConfirmation implements Confirmation {
+public class FirmwareStatusNotificationConfirmation extends Confirmation {
 
   public FirmwareStatusNotificationConfirmation() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsConfirmation.java
@@ -34,7 +34,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "getDiagnosticsResponse")
-public class GetDiagnosticsConfirmation implements Confirmation {
+public class GetDiagnosticsConfirmation extends Confirmation {
   private String fileName;
 
   @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareConfirmation.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * Sent by the Charge Point to the Central System in response to an {@link UpdateFirmwareRequest}.
  */
 @XmlRootElement(name = "updateFirmwareResponse")
-public class UpdateFirmwareConfirmation implements Confirmation {
+public class UpdateFirmwareConfirmation extends Confirmation {
 
   public UpdateFirmwareConfirmation() {}
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/GetLocalListVersionConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/GetLocalListVersionConfirmation.java
@@ -32,7 +32,7 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
-public class GetLocalListVersionConfirmation implements Confirmation {
+public class GetLocalListVersionConfirmation extends Confirmation {
 
   private Integer listVersion = -2;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListConfirmation.java
@@ -32,7 +32,7 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
-public class SendLocalListConfirmation implements Confirmation {
+public class SendLocalListConfirmation extends Confirmation {
 
   private UpdateStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/remotetrigger/TriggerMessageConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/remotetrigger/TriggerMessageConfirmation.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "triggerMessageResponse")
-public class TriggerMessageConfirmation implements Confirmation {
+public class TriggerMessageConfirmation extends Confirmation {
 
   private TriggerMessageStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/CancelReservationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/CancelReservationConfirmation.java
@@ -39,7 +39,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * CancelReservationRequest}.
  */
 @XmlRootElement(name = "cancelReservationResponse")
-public class CancelReservationConfirmation implements Confirmation {
+public class CancelReservationConfirmation extends Confirmation {
 
   private CancelReservationStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/ReserveNowConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/ReserveNowConfirmation.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System in response to an {@link ReserveNowRequest}. */
 @XmlRootElement(name = "reserveNowResponse")
-public class ReserveNowConfirmation implements Confirmation {
+public class ReserveNowConfirmation extends Confirmation {
 
   private ReservationStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/CertificateSignedConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/CertificateSignedConfirmation.java
@@ -32,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class CertificateSignedConfirmation implements Confirmation {
+public class CertificateSignedConfirmation extends Confirmation {
 
   private CertificateSignedStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/DeleteCertificateConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/DeleteCertificateConfirmation.java
@@ -32,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class DeleteCertificateConfirmation implements Confirmation {
+public class DeleteCertificateConfirmation extends Confirmation {
 
   private DeleteCertificateStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/ExtendedTriggerMessageConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/ExtendedTriggerMessageConfirmation.java
@@ -32,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class ExtendedTriggerMessageConfirmation implements Confirmation {
+public class ExtendedTriggerMessageConfirmation extends Confirmation {
 
   private TriggerMessageStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetInstalledCertificateIdsConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetInstalledCertificateIdsConfirmation.java
@@ -34,7 +34,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class GetInstalledCertificateIdsConfirmation implements Confirmation {
+public class GetInstalledCertificateIdsConfirmation extends Confirmation {
 
   private GetInstalledCertificateStatusEnumType status;
   private CertificateHashDataType[] certificateHashData;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetLogConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetLogConfirmation.java
@@ -35,7 +35,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class GetLogConfirmation implements Confirmation {
+public class GetLogConfirmation extends Confirmation {
 
   private static final transient Validator filenameValidator =
     new ValidatorBuilder()

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/InstallCertificateConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/InstallCertificateConfirmation.java
@@ -32,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class InstallCertificateConfirmation implements Confirmation {
+public class InstallCertificateConfirmation extends Confirmation {
 
   private CertificateStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/LogStatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/LogStatusNotificationConfirmation.java
@@ -31,7 +31,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class LogStatusNotificationConfirmation implements Confirmation {
+public class LogStatusNotificationConfirmation extends Confirmation {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SecurityEventNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SecurityEventNotificationConfirmation.java
@@ -31,7 +31,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SecurityEventNotificationConfirmation implements Confirmation {
+public class SecurityEventNotificationConfirmation extends Confirmation {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignCertificateConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignCertificateConfirmation.java
@@ -32,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignCertificateConfirmation implements Confirmation {
+public class SignCertificateConfirmation extends Confirmation {
 
   private GenericStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedFirmwareStatusNotificationConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedFirmwareStatusNotificationConfirmation.java
@@ -31,7 +31,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignedFirmwareStatusNotificationConfirmation implements Confirmation {
+public class SignedFirmwareStatusNotificationConfirmation extends Confirmation {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedUpdateFirmwareConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedUpdateFirmwareConfirmation.java
@@ -32,7 +32,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignedUpdateFirmwareConfirmation implements Confirmation {
+public class SignedUpdateFirmwareConfirmation extends Confirmation {
 
   private UpdateFirmwareStatusEnumType status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ClearChargingProfileConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ClearChargingProfileConfirmation.java
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "clearChargingProfileResponse")
-public class ClearChargingProfileConfirmation implements Confirmation {
+public class ClearChargingProfileConfirmation extends Confirmation {
 
   private ClearChargingProfileStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/GetCompositeScheduleConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/GetCompositeScheduleConfirmation.java
@@ -33,7 +33,7 @@ import java.time.ZonedDateTime;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
 
-public class GetCompositeScheduleConfirmation implements Confirmation {
+public class GetCompositeScheduleConfirmation extends Confirmation {
 
   private GetCompositeScheduleStatus status;
   private Integer connectorId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileConfirmation.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileConfirmation.java
@@ -34,7 +34,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "setChargingProfileResponse")
-public class SetChargingProfileConfirmation implements Confirmation {
+public class SetChargingProfileConfirmation extends Confirmation {
 
   private ChargingProfileStatus status;
 

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/TimeoutSessionTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/test/TimeoutSessionTest.java
@@ -76,7 +76,7 @@ public class TimeoutSessionTest {
     session.open(null, sessionEvents);
 
     // When
-    sessionEvents.handleConnectionClosed();
+    sessionEvents.handleConnectionClosed(0, null);
 
     // Then
     verify(timeoutTimer, times(1)).end();
@@ -100,7 +100,7 @@ public class TimeoutSessionTest {
     session.accept(sessionEvents);
 
     // When
-    sessionEvents.handleConnectionClosed();
+    sessionEvents.handleConnectionClosed(0, null);
 
     // Then
     verify(timeoutTimer, times(1)).end();

--- a/ocpp-v2_0-test/src/main/java/eu/chargetime/ocpp/test/FakeChargePoint.java
+++ b/ocpp-v2_0-test/src/main/java/eu/chargetime/ocpp/test/FakeChargePoint.java
@@ -49,7 +49,7 @@ public class FakeChargePoint {
           public void connectionOpened() {}
 
           @Override
-          public void connectionClosed() {}
+          public void connectionClosed(int code, String reason) {}
         });
   }
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/BootNotificationConfirmation.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/BootNotificationConfirmation.java
@@ -34,7 +34,7 @@ import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /** sent by the CSMS to the Charging Station in response to a {@link BootNotificationRequest}. */
-public class BootNotificationConfirmation implements Confirmation {
+public class BootNotificationConfirmation extends Confirmation {
   private transient RequiredValidator validator = new RequiredValidator();
 
   private ZonedDateTime currentTime;

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/GetVariablesConfirmation.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/GetVariablesConfirmation.java
@@ -31,7 +31,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class GetVariablesConfirmation implements Confirmation {
+public class GetVariablesConfirmation extends Confirmation {
 
   private GetVariableResultType[] getVariableResult;
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/SetVariablesConfirmation.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/SetVariablesConfirmation.java
@@ -37,7 +37,7 @@ import java.util.Objects;
  * This contains the field definition of the SetVariablesResponse PDU sent by the Charging Station
  * to the CSMS in response to a SetVariablesRequest.
  */
-public class SetVariablesConfirmation implements Confirmation {
+public class SetVariablesConfirmation extends Confirmation {
   private transient Validator<Object> requiredValidator = new RequiredValidator();
 
   private SetVariableResultType[] setVariableResult;

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/StatusNotificationConfirmation.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/StatusNotificationConfirmation.java
@@ -29,7 +29,7 @@ import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
-public class StatusNotificationConfirmation implements Confirmation {
+public class StatusNotificationConfirmation extends Confirmation {
 
   @Override
   public boolean validate() {


### PR DESCRIPTION
The reason for this change is to have different reconnect strategies depending on why you are disconnected.
If the OCPP rejected you because of a 404 or something like that, or if you simply lose connection.

My question here is what do do with explicit disconnects from within the code?
Right now I pass 0, "disconnect() method called" - but it looks a bit hacky.
2 other alternatives are:

-  a separate disconnect method without arguments - but then the implementation must handle 2 disconnect() methods.
- nullable Integer so no error code is passed instead of a magic 0 or -1 or something