### PR TITLE
Asynchronous execution

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONCommunicator.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONCommunicator.java
@@ -5,6 +5,8 @@ import eu.chargetime.ocpp.model.CallErrorMessage;
 import eu.chargetime.ocpp.model.CallMessage;
 import eu.chargetime.ocpp.model.CallResultMessage;
 import eu.chargetime.ocpp.model.Message;
+import eu.chargetime.ocpp.model.Exclude;
+
 import java.lang.reflect.Type;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -99,6 +101,18 @@ public class JSONCommunicator extends Communicator {
   static {
     GsonBuilder builder = new GsonBuilder();
     builder.registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeSerializer());
+    builder.addSerializationExclusionStrategy(new ExclusionStrategy() {
+      @Override
+      public boolean shouldSkipClass(Class<?> clazz) {
+        return false;
+      }
+
+      @Override
+      public boolean shouldSkipField(FieldAttributes field) {
+        return field.getAnnotation(Exclude.class) != null;
+      }
+    });
+
     gson = builder.disableHtmlEscaping().create();
   }
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Client.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Client.java
@@ -97,6 +97,11 @@ public class Client {
           }
 
           @Override
+          public boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+            return session.completePendingPromise(uniqueId, confirmation);
+          }
+
+          @Override
           public void handleError(
               String uniqueId, String errorCode, String errorDescription, Object payload) {
             Optional<CompletableFuture<Confirmation>> promiseOptional =
@@ -164,5 +169,9 @@ public class Client {
 
   public UUID getSessionId() {
     return this.session.getSessionId();
+  }
+
+  public boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+    return session.completePendingPromise(uniqueId, confirmation);
   }
 }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ISession.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ISession.java
@@ -1,5 +1,6 @@
 package eu.chargetime.ocpp;
 
+import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
 import java.util.UUID;
 
@@ -38,6 +39,8 @@ public interface ISession {
   String storeRequest(Request payload);
 
   void sendRequest(String action, Request payload, String uuid);
+
+  boolean completePendingPromise(String id, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException;
 
   void close();
 }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/RequestDispatcher.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/RequestDispatcher.java
@@ -38,10 +38,8 @@ public class RequestDispatcher implements IRequestDispactcher {
     this.fulfiller = fulfiller;
   }
 
-  public CompletableFuture<Confirmation> handleRequest(Request request) {
-    CompletableFuture<Confirmation> promise = new CompletableFuture<>();
+  public void handleRequest(CompletableFuture<Confirmation> promise, Request request) {
     fulfiller.fulfill(promise, eventHandler, request);
-    return promise;
   }
 
   public void setEventHandler(SessionEvents eventHandler) {

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/SessionEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/SessionEvents.java
@@ -50,6 +50,15 @@ public interface SessionEvents {
   Confirmation handleRequest(Request request) throws UnsupportedFeatureException;
 
   /**
+   * Completes a pending request {@link Request}.
+   *
+   * @param uniqueId the unique id used for the {@link Request}.
+   * @param confirmation the {@link Confirmation} to the {@link Request}.
+   * @return a boolean indicating if pending request was found.
+   */
+  boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException;
+
+  /**
    * Handle a error to a {@link Request}.
    *
    * @param uniqueId the unique identifier for the {@link Request}.

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/SimplePromiseFulfiller.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/SimplePromiseFulfiller.java
@@ -39,7 +39,10 @@ public class SimplePromiseFulfiller implements PromiseFulfiller {
       CompletableFuture<Confirmation> promise, SessionEvents eventHandler, Request request) {
     try {
       Confirmation conf = eventHandler.handleRequest(request);
-      promise.complete(conf);
+      // Confirmation may be null, in this case asynchronous execution is assumed
+      if (conf != null) {
+        eventHandler.asyncCompleteRequest(request.getOcppMessageId(), conf);
+      }
     } catch (Exception ex) {
       logger.warn("fulfillPromis() failed", ex);
       promise.completeExceptionally(ex);

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/Exclude.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/Exclude.java
@@ -1,0 +1,10 @@
+package eu.chargetime.ocpp.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Exclude {}

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/Request.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/Request.java
@@ -30,4 +30,6 @@ SOFTWARE.
 /** Interface used to flag a model as Request payload. */
 public interface Request extends Validatable {
   boolean transactionRelated();
+  String getOcppMessageId();
+  void setOcppMessageId(String id);
 }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/RequestWithId.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/RequestWithId.java
@@ -1,0 +1,16 @@
+package eu.chargetime.ocpp.model;
+
+public abstract class RequestWithId implements Request {
+  @Override
+  public String getOcppMessageId() {
+    return ocppMessageId;
+  }
+
+  @Override
+  public void setOcppMessageId(String requestId) {
+    this.ocppMessageId = requestId;
+  }
+
+  @Exclude
+  private String ocppMessageId;
+}

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/model/TestRequest.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/model/TestRequest.java
@@ -27,7 +27,7 @@ package eu.chargetime.ocpp.model;
  */
 
 /** Test implementation of the Request interface. Used for tests. */
-public class TestRequest implements Request {
+public class TestRequest extends RequestWithId {
   @Override
   public boolean validate() {
     return true;

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/SessionTest.java
@@ -8,6 +8,7 @@ import eu.chargetime.ocpp.*;
 import eu.chargetime.ocpp.feature.Feature;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.TestRequest;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -85,7 +86,7 @@ public class SessionTest {
     // Given
     String someAction = "Test action";
     Request someRequest =
-        new Request() {
+        new RequestWithId() {
           @Override
           public boolean transactionRelated() {
             return false;

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/JSONTestClient.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/JSONTestClient.java
@@ -81,6 +81,11 @@ public class JSONTestClient implements IClientAPI {
   }
 
   @Override
+  public boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+    return client.asyncCompleteRequest(uniqueId, confirmation);
+  }
+
+  @Override
   public void disconnect() {
     client.disconnect();
   }

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/JSONTestServer.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/JSONTestServer.java
@@ -100,4 +100,9 @@ public class JSONTestServer implements IServerAPI {
       throws OccurenceConstraintException, UnsupportedFeatureException, NotConnectedException {
     return server.send(session, request);
   }
+
+  @Override
+  public boolean asyncCompleteRequest(UUID sessionIndex, String uniqueId, Confirmation confirmation) throws NotConnectedException, UnsupportedFeatureException, OccurenceConstraintException {
+    return server.asyncCompleteRequest(sessionIndex, uniqueId, confirmation);
+  }
 }

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/SOAPTestClient.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/SOAPTestClient.java
@@ -98,6 +98,11 @@ public class SOAPTestClient implements IClientAPI {
     return client.send(request);
   }
 
+  @Override
+  public boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+    return client.asyncCompleteRequest(uniqueId, confirmation);
+  }
+
   /** Disconnect from server Closes down local callback service. */
   public void disconnect() {
     this.client.disconnect();

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/SOAPTestServer.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/SOAPTestServer.java
@@ -87,4 +87,9 @@ public class SOAPTestServer implements IServerAPI {
       throws OccurenceConstraintException, UnsupportedFeatureException, NotConnectedException {
     return server.send(session, request);
   }
+
+  @Override
+  public boolean asyncCompleteRequest(UUID sessionIndex, String uniqueId, Confirmation confirmation) throws NotConnectedException, UnsupportedFeatureException, OccurenceConstraintException {
+    return server.asyncCompleteRequest(sessionIndex, uniqueId, confirmation);
+  }
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/IClientAPI.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/IClientAPI.java
@@ -39,6 +39,8 @@ public interface IClientAPI {
   CompletionStage<Confirmation> send(Request request)
       throws OccurenceConstraintException, UnsupportedFeatureException;
 
+  boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException;
+
   void disconnect();
 
   boolean isClosed();

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/IServerAPI.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/IServerAPI.java
@@ -46,4 +46,7 @@ public interface IServerAPI {
 
   CompletionStage<Confirmation> send(UUID sessionIndex, Request request)
       throws OccurenceConstraintException, UnsupportedFeatureException, NotConnectedException;
+
+  boolean asyncCompleteRequest(UUID sessionIndex, String uniqueId, Confirmation confirmation)
+      throws NotConnectedException, UnsupportedFeatureException, OccurenceConstraintException;
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONClient.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONClient.java
@@ -164,6 +164,11 @@ public class JSONClient implements IClientAPI {
   }
 
   @Override
+  public boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+    return client.asyncCompleteRequest(uniqueId, confirmation);
+  }
+
+  @Override
   public void disconnect() {
     client.disconnect();
   }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONServer.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONServer.java
@@ -173,4 +173,9 @@ public class JSONServer implements IServerAPI {
       throws OccurenceConstraintException, UnsupportedFeatureException, NotConnectedException {
     return server.send(session, request);
   }
+
+  @Override
+  public boolean asyncCompleteRequest(UUID sessionIndex, String uniqueId, Confirmation confirmation) throws NotConnectedException, UnsupportedFeatureException, OccurenceConstraintException {
+    return server.asyncCompleteRequest(sessionIndex, uniqueId, confirmation);
+  }
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPClient.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPClient.java
@@ -105,6 +105,11 @@ public class SOAPClient implements IClientAPI {
     return client.send(request);
   }
 
+  @Override
+  public boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+    return client.asyncCompleteRequest(uniqueId, confirmation);
+  }
+
   /** Disconnect from server Closes down local callback service. */
   public void disconnect() {
     this.client.disconnect();

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPServer.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/SOAPServer.java
@@ -87,4 +87,9 @@ public class SOAPServer implements IServerAPI {
       throws OccurenceConstraintException, UnsupportedFeatureException, NotConnectedException {
     return server.send(session, request);
   }
+
+  @Override
+  public boolean asyncCompleteRequest(UUID sessionIndex, String uniqueId, Confirmation confirmation) throws NotConnectedException, UnsupportedFeatureException, OccurenceConstraintException {
+    return server.asyncCompleteRequest(sessionIndex, uniqueId, confirmation);
+  }
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/TimeoutSessionDecorator.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/TimeoutSessionDecorator.java
@@ -88,6 +88,11 @@ public class TimeoutSessionDecorator implements ISession {
   }
 
   @Override
+  public boolean completePendingPromise(String id, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+    return this.session.completePendingPromise(id, confirmation);
+  }
+
+  @Override
   public void close() {
     this.session.close();
   }
@@ -114,6 +119,11 @@ public class TimeoutSessionDecorator implements ISession {
           }
         }
         return confirmation;
+      }
+
+      @Override
+      public boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+        return eventHandler.asyncCompleteRequest(uniqueId, confirmation);
       }
 
       @Override

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/AuthorizeRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/AuthorizeRequest.java
@@ -1,7 +1,7 @@
 package eu.chargetime.ocpp.model.core;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -39,7 +39,7 @@ SOFTWARE.
 
 /** Sent by the Charge Point to the Central System. */
 @XmlRootElement
-public class AuthorizeRequest implements Request {
+public class AuthorizeRequest extends RequestWithId {
 
   private static final int IDTAG_MAX_LENGTH = 20;
   private static final String ERROR_MESSAGE = "Exceeded limit of " + IDTAG_MAX_LENGTH + " chars";

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/BootNotificationRequest.java
@@ -30,7 +30,7 @@ SOFTWARE.
 */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -52,7 +52,7 @@ import javax.xml.bind.annotation.XmlType;
       "meterType",
       "meterSerialNumber"
     })
-public class BootNotificationRequest implements Request {
+public class BootNotificationRequest extends RequestWithId {
 
   private static final int STRING_20_CHAR_MAX_LENGTH = 20;
   private static final int STRING_25_CHAR_MAX_LENGTH = 25;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeAvailabilityRequest.java
@@ -30,7 +30,7 @@ SOFTWARE.
 */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
@@ -38,7 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
-public class ChangeAvailabilityRequest implements Request {
+public class ChangeAvailabilityRequest extends RequestWithId {
 
   private Integer connectorId = -1;
   private AvailabilityType type;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeConfigurationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ChangeConfigurationRequest.java
@@ -28,7 +28,7 @@ SOFTWARE.
 */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -44,7 +44,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement
 @XmlType(propOrder = {"key", "value"})
-public class ChangeConfigurationRequest implements Request {
+public class ChangeConfigurationRequest extends RequestWithId {
 
   private static final String ERROR_MESSAGE = "Exceeded limit of %s chars";
   private static final int KEY_MAX_LENGTH = 50;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ClearCacheRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ClearCacheRequest.java
@@ -27,14 +27,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point. Request holds no values and is always valid. */
 @XmlRootElement
-public class ClearCacheRequest implements Request {
+public class ClearCacheRequest extends RequestWithId {
   @Override
   public boolean validate() {
     return true;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/DataTransferRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/DataTransferRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -39,7 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 /** Sent either by the Central System to the Charge Point or vice versa. */
 @XmlRootElement
 @XmlType(propOrder = {"vendorId", "messageId", "data"})
-public class DataTransferRequest implements Request {
+public class DataTransferRequest extends RequestWithId {
 
   private static final String ERROR_MESSAGE = "Exceeded limit of %s chars";
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/GetConfigurationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/GetConfigurationRequest.java
@@ -28,7 +28,7 @@ SOFTWARE.
 */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
@@ -37,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the the Central System to the Charge Point. */
 @XmlRootElement
-public class GetConfigurationRequest implements Request {
+public class GetConfigurationRequest extends RequestWithId {
 
   private String[] key;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/HeartbeatRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/HeartbeatRequest.java
@@ -26,14 +26,14 @@ package eu.chargetime.ocpp.model.core;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System. Request holds no values and is always valid. */
 @XmlRootElement
-public class HeartbeatRequest implements Request {
+public class HeartbeatRequest extends RequestWithId {
   @Override
   public boolean validate() {
     return true;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/MeterValuesRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
@@ -43,7 +43,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement
 @XmlType(propOrder = {"connectorId", "transactionId", "meterValue"})
-public class MeterValuesRequest implements Request {
+public class MeterValuesRequest extends RequestWithId {
 
   private Integer connectorId;
   private Integer transactionId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStartTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStartTransactionRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -39,7 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 /** Sent to Charge Point by Central System. */
 @XmlRootElement
 @XmlType(propOrder = {"connectorId", "idTag", "chargingProfile"})
-public class RemoteStartTransactionRequest implements Request {
+public class RemoteStartTransactionRequest extends RequestWithId {
 
   private Integer connectorId;
   private String idTag;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStopTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/RemoteStopTransactionRequest.java
@@ -27,7 +27,7 @@ package eu.chargetime.ocpp.model.core;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** sent to Charge Point by Central System. */
 @XmlRootElement
-public class RemoteStopTransactionRequest implements Request {
+public class RemoteStopTransactionRequest extends RequestWithId {
 
   private Integer transactionId;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ResetRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/ResetRequest.java
@@ -27,7 +27,7 @@ package eu.chargetime.ocpp.model.core;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
@@ -35,7 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
-public class ResetRequest implements Request {
+public class ResetRequest extends RequestWithId {
 
   private ResetType type;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StartTransactionRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.XmlType;
 /** Sent by the Charge Point to the Central System. */
 @XmlRootElement
 @XmlType(propOrder = {"connectorId", "idTag", "timestamp", "meterStart", "reservationId"})
-public class StartTransactionRequest implements Request {
+public class StartTransactionRequest extends RequestWithId {
 
   private static final int IDTAG_MAX_LENGTH = 20;
   private static final String IDTAG_ERROR_MESSAGE =

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StatusNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StatusNotificationRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
@@ -49,7 +49,7 @@ import javax.xml.bind.annotation.XmlType;
       "vendorId",
       "vendorErrorCode"
     })
-public class StatusNotificationRequest implements Request {
+public class StatusNotificationRequest extends RequestWithId {
 
   private static final String ERROR_MESSAGE = "Exceeds limit of %s chars";
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/StopTransactionRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
@@ -42,7 +42,7 @@ import javax.xml.bind.annotation.XmlType;
 @XmlRootElement
 @XmlType(
     propOrder = {"transactionId", "idTag", "timestamp", "meterStop", "reason", "transactionData"})
-public class StopTransactionRequest implements Request {
+public class StopTransactionRequest extends RequestWithId {
 
   private String idTag;
   private Integer meterStop;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/UnlockConnectorRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/core/UnlockConnectorRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.core;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
-public class UnlockConnectorRequest implements Request {
+public class UnlockConnectorRequest extends RequestWithId {
 
   private Integer connectorId;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/DiagnosticsStatusNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/DiagnosticsStatusNotificationRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.firmware;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System. */
 @XmlRootElement
-public class DiagnosticsStatusNotificationRequest implements Request {
+public class DiagnosticsStatusNotificationRequest extends RequestWithId {
 
   private DiagnosticsStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/FirmwareStatusNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/FirmwareStatusNotificationRequest.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp.model.firmware;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Charge Point to the Central System. */
 @XmlRootElement
-public class FirmwareStatusNotificationRequest implements Request {
+public class FirmwareStatusNotificationRequest extends RequestWithId {
 
   private FirmwareStatus status;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsRequest.java
@@ -26,7 +26,7 @@ package eu.chargetime.ocpp.model.firmware;
   SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
 import java.util.Objects;
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
 @XmlType(propOrder = {"location", "startTime", "stopTime", "retries", "retryInterval"})
-public class GetDiagnosticsRequest implements Request {
+public class GetDiagnosticsRequest extends RequestWithId {
 
   private String location;
   private Integer retries;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareRequest.java
@@ -29,7 +29,7 @@ package eu.chargetime.ocpp.model.firmware;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
 import java.util.Objects;
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.XmlType;
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
 @XmlType(propOrder = {"location", "retries", "retrieveDate", "retryInterval"})
-public class UpdateFirmwareRequest implements Request {
+public class UpdateFirmwareRequest extends RequestWithId {
 
   private String location;
   private Integer retries;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/GetLocalListVersionRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/GetLocalListVersionRequest.java
@@ -26,11 +26,11 @@ package eu.chargetime.ocpp.model.localauthlist;
  * SOFTWARE.
  */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
-public class GetLocalListVersionRequest implements Request {
+public class GetLocalListVersionRequest extends RequestWithId {
 
   @Override
   public boolean validate() {

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/localauthlist/SendLocalListRequest.java
@@ -28,12 +28,12 @@ package eu.chargetime.ocpp.model.localauthlist;
  */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class SendLocalListRequest implements Request {
+public class SendLocalListRequest extends RequestWithId {
 
   private Integer listVersion = 0;
   private AuthorizationData[] localAuthorizationList = null;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/remotetrigger/TriggerMessageRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/remotetrigger/TriggerMessageRequest.java
@@ -30,7 +30,7 @@ SOFTWARE.
 */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
@@ -39,7 +39,7 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement
 @XmlType(propOrder = {"requestedMessage", "connectorId"})
-public class TriggerMessageRequest implements Request {
+public class TriggerMessageRequest extends RequestWithId {
 
   private Integer connectorId;
   private TriggerMessageRequestType requestedMessage;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/CancelReservationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/CancelReservationRequest.java
@@ -1,6 +1,6 @@
 package eu.chargetime.ocpp.model.reservation;
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
-public class CancelReservationRequest implements Request {
+public class CancelReservationRequest extends RequestWithId {
 
   private Integer reservationId;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/ReserveNowRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/reservation/ReserveNowRequest.java
@@ -1,7 +1,7 @@
 package eu.chargetime.ocpp.model.reservation;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.ModelUtil;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
@@ -41,7 +41,7 @@ import javax.xml.bind.annotation.XmlType;
 /** Sent by the Central System to the Charge Point. */
 @XmlRootElement
 @XmlType(propOrder = {"connectorId", "expiryDate", "idTag", "parentIdTag", "reservationId"})
-public class ReserveNowRequest implements Request {
+public class ReserveNowRequest extends RequestWithId {
 
   private static final int ID_TAG_MAX_LENGTH = 20;
   private static final String ERROR_MESSAGE = "Exceeded limit of " + ID_TAG_MAX_LENGTH + " chars";

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/CertificateSignedRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/CertificateSignedRequest.java
@@ -26,7 +26,7 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.validation.StringMaxLengthValidationRule;
 import eu.chargetime.ocpp.model.validation.Validator;
 import eu.chargetime.ocpp.model.validation.ValidatorBuilder;
@@ -34,7 +34,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class CertificateSignedRequest implements Request {
+public class CertificateSignedRequest extends RequestWithId {
 
   private static final transient Validator certificateChainValidator =
     new ValidatorBuilder()

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/DeleteCertificateRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/DeleteCertificateRequest.java
@@ -26,13 +26,13 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.securityext.types.CertificateHashDataType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class DeleteCertificateRequest implements Request {
+public class DeleteCertificateRequest extends RequestWithId {
 
   private CertificateHashDataType certificateHashData;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/ExtendedTriggerMessageRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/ExtendedTriggerMessageRequest.java
@@ -27,13 +27,13 @@ package eu.chargetime.ocpp.model.securityext;
 */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.securityext.types.MessageTriggerEnumType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class ExtendedTriggerMessageRequest implements Request {
+public class ExtendedTriggerMessageRequest extends RequestWithId {
 
   private MessageTriggerEnumType requestedMessage;
   private Integer connectorId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetInstalledCertificateIdsRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetInstalledCertificateIdsRequest.java
@@ -26,13 +26,13 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.securityext.types.CertificateUseEnumType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class GetInstalledCertificateIdsRequest implements Request {
+public class GetInstalledCertificateIdsRequest extends RequestWithId {
 
   private CertificateUseEnumType certificateType;
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetLogRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/GetLogRequest.java
@@ -26,14 +26,14 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.securityext.types.LogEnumType;
 import eu.chargetime.ocpp.model.securityext.types.LogParametersType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class GetLogRequest implements Request {
+public class GetLogRequest extends RequestWithId {
 
   private LogEnumType logType;
   private Integer requestId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/InstallCertificateRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/InstallCertificateRequest.java
@@ -26,7 +26,7 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.securityext.types.CertificateUseEnumType;
 import eu.chargetime.ocpp.model.validation.StringMaxLengthValidationRule;
 import eu.chargetime.ocpp.model.validation.Validator;
@@ -35,7 +35,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class InstallCertificateRequest implements Request {
+public class InstallCertificateRequest extends RequestWithId {
 
   private static final transient Validator certificateValidator =
     new ValidatorBuilder()

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/LogStatusNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/LogStatusNotificationRequest.java
@@ -26,13 +26,13 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.securityext.types.UploadLogStatusEnumType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class LogStatusNotificationRequest implements Request {
+public class LogStatusNotificationRequest extends RequestWithId {
 
   private UploadLogStatusEnumType status;
   private Integer requestId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SecurityEventNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SecurityEventNotificationRequest.java
@@ -26,7 +26,7 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.validation.StringMaxLengthValidationRule;
 import eu.chargetime.ocpp.model.validation.Validator;
 import eu.chargetime.ocpp.model.validation.ValidatorBuilder;
@@ -35,7 +35,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
-public class SecurityEventNotificationRequest implements Request {
+public class SecurityEventNotificationRequest extends RequestWithId {
 
   private static final transient Validator typeValidator =
     new ValidatorBuilder()

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignCertificateRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignCertificateRequest.java
@@ -26,7 +26,7 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.validation.StringMaxLengthValidationRule;
 import eu.chargetime.ocpp.model.validation.Validator;
 import eu.chargetime.ocpp.model.validation.ValidatorBuilder;
@@ -34,7 +34,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignCertificateRequest implements Request {
+public class SignCertificateRequest extends RequestWithId {
 
   private static final transient Validator csrValidator =
     new ValidatorBuilder()

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedFirmwareStatusNotificationRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedFirmwareStatusNotificationRequest.java
@@ -26,14 +26,14 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.remotetrigger.TriggerMessageRequest;
 import eu.chargetime.ocpp.model.securityext.types.FirmwareStatusEnumType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignedFirmwareStatusNotificationRequest implements Request {
+public class SignedFirmwareStatusNotificationRequest extends RequestWithId {
 
   private FirmwareStatusEnumType status;
   private Integer requestId;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedUpdateFirmwareRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/securityext/SignedUpdateFirmwareRequest.java
@@ -26,13 +26,13 @@ package eu.chargetime.ocpp.model.securityext;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.securityext.types.FirmwareType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 
 import java.util.Objects;
 
-public class SignedUpdateFirmwareRequest implements Request {
+public class SignedUpdateFirmwareRequest extends RequestWithId {
 
   private Integer retries;
   private Integer retryInterval;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ClearChargingProfileRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/ClearChargingProfileRequest.java
@@ -1,7 +1,7 @@
 package eu.chargetime.ocpp.model.smartcharging;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.core.ChargingProfilePurposeType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 
 @XmlRootElement
-public class ClearChargingProfileRequest implements Request {
+public class ClearChargingProfileRequest extends RequestWithId {
   private Integer id;
   private Integer connectorId;
   private ChargingProfilePurposeType chargingProfilePurpose;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/GetCompositeScheduleRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/GetCompositeScheduleRequest.java
@@ -27,14 +27,14 @@ package eu.chargetime.ocpp.model.smartcharging;
 */
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
-public class GetCompositeScheduleRequest implements Request {
+public class GetCompositeScheduleRequest extends RequestWithId {
 
   private Integer connectorId;
   private Integer duration;

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/smartcharging/SetChargingProfileRequest.java
@@ -1,7 +1,7 @@
 package eu.chargetime.ocpp.model.smartcharging;
 
 import eu.chargetime.ocpp.PropertyConstraintException;
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.core.ChargingProfile;
 import eu.chargetime.ocpp.model.core.ChargingProfilePurposeType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
@@ -37,7 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 
 @XmlRootElement
-public class SetChargingProfileRequest implements Request {
+public class SetChargingProfileRequest extends RequestWithId {
 
   private Integer connectorId;
   private ChargingProfile csChargingProfiles;

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/IClientAPI.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/IClientAPI.java
@@ -39,6 +39,8 @@ public interface IClientAPI {
   CompletionStage<Confirmation> send(Request request)
       throws OccurenceConstraintException, UnsupportedFeatureException;
 
+  boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException;
+
   void disconnect();
 
   boolean isClosed();

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/IServerAPI.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/IServerAPI.java
@@ -46,4 +46,7 @@ public interface IServerAPI {
 
   CompletionStage<Confirmation> send(UUID sessionIndex, Request request)
       throws OccurenceConstraintException, UnsupportedFeatureException, NotConnectedException;
+
+  boolean asyncCompleteRequest(UUID sessionIndex, String uniqueId, Confirmation confirmation)
+          throws NotConnectedException, UnsupportedFeatureException, OccurenceConstraintException;
 }

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/JSONClient.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/JSONClient.java
@@ -148,6 +148,11 @@ public class JSONClient implements IClientAPI {
   }
 
   @Override
+  public boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
+    return client.asyncCompleteRequest(uniqueId, confirmation);
+  }
+
+  @Override
   public void disconnect() {
     client.disconnect();
   }

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/JSONServer.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/JSONServer.java
@@ -155,4 +155,9 @@ public class JSONServer implements IServerAPI {
       throws OccurenceConstraintException, UnsupportedFeatureException, NotConnectedException {
     return server.send(session, request);
   }
+
+  @Override
+  public boolean asyncCompleteRequest(UUID sessionIndex, String uniqueId, Confirmation confirmation) throws NotConnectedException, UnsupportedFeatureException, OccurenceConstraintException {
+    return server.asyncCompleteRequest(sessionIndex, uniqueId, confirmation);
+  }
 }

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/BootNotificationRequest.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/BootNotificationRequest.java
@@ -25,7 +25,7 @@ package eu.chargetime.ocpp.model.basic;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.basic.types.BootReasonEnumType;
 import eu.chargetime.ocpp.model.basic.types.ChargingStationType;
 import eu.chargetime.ocpp.model.validation.RequiredValidator;
@@ -33,7 +33,7 @@ import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Objects;
 
 /** Sent by the Charging Station to the CSMS. */
-public class BootNotificationRequest implements Request {
+public class BootNotificationRequest extends RequestWithId {
   private transient RequiredValidator validator = new RequiredValidator();
 
   private BootReasonEnumType reason;

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/GetVariablesRequest.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/GetVariablesRequest.java
@@ -25,13 +25,13 @@ package eu.chargetime.ocpp.model.basic;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.basic.types.GetVariableDataType;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class GetVariablesRequest implements Request {
+public class GetVariablesRequest extends RequestWithId {
 
   private GetVariableDataType[] getVariableData;
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/SetVariablesRequest.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/SetVariablesRequest.java
@@ -25,7 +25,7 @@ package eu.chargetime.ocpp.model.basic;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.basic.types.SetVariableDataType;
 import eu.chargetime.ocpp.model.validation.RequiredValidator;
 import eu.chargetime.ocpp.model.validation.Validator;
@@ -37,7 +37,7 @@ import java.util.Objects;
  * This contains the field definition of the SetVariablesRequest PDU sent by the CSMS to the
  * Charging Station.
  */
-public class SetVariablesRequest implements Request {
+public class SetVariablesRequest extends RequestWithId {
   private transient Validator<Object> requiredValidator = new RequiredValidator();
   private SetVariableDataType[] setVariableData;
 

--- a/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/StatusNotificationRequest.java
+++ b/ocpp-v2_0/src/main/java/eu/chargetime/ocpp/model/basic/StatusNotificationRequest.java
@@ -25,14 +25,14 @@ package eu.chargetime.ocpp.model.basic;
    SOFTWARE.
 */
 
-import eu.chargetime.ocpp.model.Request;
+import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.model.basic.types.ConnectorStatusEnumType;
 import eu.chargetime.ocpp.model.validation.RequiredValidator;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
-public class StatusNotificationRequest implements Request {
+public class StatusNotificationRequest extends RequestWithId {
 
   private transient RequiredValidator validator = new RequiredValidator();
 


### PR DESCRIPTION
This pull request resolves #172 . It introduces ability to skip executing request by server or client immediately, and allows to complete it at later time by invoking new methods of `IClient` and `IServer` interfaces:

```
IClient:

boolean asyncCompleteRequest(String uniqueId, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException;
```

```
IServer:

boolean asyncCompleteRequest(UUID sessionIndex, String uniqueId, Confirmation confirmation)
      throws NotConnectedException, UnsupportedFeatureException, OccurenceConstraintException;
```

Changes are not breaking, existing code will continue to work without any need for modification. Usage of new methods and asynchronous mode are fully optional. The following diagram provides an example of using the asynchronous mode:

[![async_diagram](https://user-images.githubusercontent.com/39849806/192251651-bc51cc50-6765-4993-8cd1-39f20660ea28.png)](https://www.planttext.com/?text=VLB1JiCm3BtdAtA40p_G0nfKI9mGWo-8Ec-BbDgPuqo2hoTjrfAqsqvn_9wVNnnlWXYMs3kbV0fiPxr1qQspW5Able7Fm5TIR-T4VJUuSmlu2quHWcmZH5W0mHC6M2DZvfEfWn28bLBPY7vwlZHhz2kHV93OlUsCMC9B5vNnVsPfgz77CNY9SYIslr0NbTH1e3JUwDDmQBvRCPbZaCYeCReqqFenQ-43YEuJPWwWIcHWrhNDt7wjkMJw7CxArrmKun-ayrNTd4P5hrqNqAtHp_htHsV23tOjzTw1JF_pCDK-5j-RLsAz22tXtd8_nafj07TfhVy0)

It also resolves #86 by allowing client to call `asyncCompleteRequest` in `handleTriggerMessageRequest` before sending a message requested by `TriggerMessageRequest`, and finally return `null` from `handleTriggerMessageRequest`.

One serious change is that in order to know OCPP message ID of the request in its handler, it has been included into every class which implemented `Request` interface. I enhanced `Request` interface with `getOcppMessageId` and `setOcppMessageId` methods, and implemented them in abstract class `RequestWithId` which implements `Request`. Then every class which formerly implemented `Request` interface now extends `RequestWithId`. Now handler implementation can simple call `getOcppMessageId` on the instance of `Request` it got. I have taken measures to not include `ocppMessageId` into serialized message, by introducing `Exclude` annotation.