### PR TITLE
Allow JSONClient reconfiguration when connected

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketTransmitter.java
@@ -152,6 +152,9 @@ public class WebSocketTransmitter implements Transmitter {
   }
 
   void configure() {
+    if (client == null) {
+      return;
+    }
     client.setReuseAddr(configuration.getParameter(JSONConfiguration.REUSE_ADDR_PARAMETER, false));
     client.setTcpNoDelay(
         configuration.getParameter(JSONConfiguration.TCP_NO_DELAY_PARAMETER, false));

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONClient.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONClient.java
@@ -144,6 +144,14 @@ public class JSONClient implements IClientAPI {
     return this;
   }
 
+  /**
+   * Applies JSONConfiguration changes when already connected. Specifically, the WebSocket ping
+   * interval can be changed without reconnecting by calling this method.
+   */
+  public void reconfigure() {
+    transmitter.configure();
+  }
+
   @Override
   public void addFeatureProfile(Profile profile) {
     featureRepository.addFeatureProfile(profile);


### PR DESCRIPTION
The WebSocket library allows changing the ping interval immediately during an ongoing connection. Expose this capability by adding a new reconfigure() method to the JSONClient class.

To make use of this, set the updated PING_INTERVAL_PARAMETER on the JSONConfiguration object passed to the JSONClient constructor, then invoke JSONClient#reconfigure().

This has been successfully verified to work.