### PR TITLE
Revert "GitHub Actions: Downgrade maven workflow to 11.0.16+8"

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        # TODO: Revert to '11'.
-        # See https://github.com/ChargeTimeEU/Java-OCA-OCPP/pull/223#issuecomment-1328048028
-        java-version: '11.0.16+8'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
This reverts the build script workaround introduced by #223.

#223 fixed #221.

java-version: '11' no longer delivers an incompatible JDK. See https://github.com/ChargeTimeEU/Java-OCA-OCPP/pull/223#issuecomment-1328119343 and following.

This reverts commit 3bc476e81163b8704042e27a88e8066d543137b2.