### PR TITLE
Allow configuration of allowed password string length

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
@@ -39,6 +39,11 @@ public class JSONConfiguration {
   public static final String CONNECT_NON_BLOCKING_PARAMETER = "CONNECT_NON_BLOCKING";
   public static final String CONNECT_TIMEOUT_IN_MS_PARAMETER = "CONNECT_TIMEOUT_IN_MS";
   public static final String WEBSOCKET_WORKER_COUNT = "WEBSOCKET_WORKER_COUNT";
+  public static final String HTTP_HEALTH_CHECK_ENABLED = "HTTP_HEALTH_CHECK_ENABLED";
+  public static final String OCPPJ_CP_MIN_PASSWORD_LENGTH = "OCPPJ_CP_MIN_PASSWORD_LENGTH";
+  public static final String OCPPJ_CP_MAX_PASSWORD_LENGTH = "OCPPJ_CP_MAX_PASSWORD_LENGTH";
+  public static final String OCPP2J_CP_MIN_PASSWORD_LENGTH = "OCPP2J_CP_MIN_PASSWORD_LENGTH";
+  public static final String OCPP2J_CP_MAX_PASSWORD_LENGTH = "OCPP2J_CP_MAX_PASSWORD_LENGTH";
 
   private final HashMap<String, Object> parameters = new HashMap<>();
 

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
@@ -166,8 +166,8 @@ public class WebSocketListener implements Listener {
                 }
               }
               if (password == null
-                  || password.length < OCPPJ_CP_MIN_PASSWORD_LENGTH
-                  || password.length > OCPPJ_CP_MAX_PASSWORD_LENGTH)
+                  || password.length < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
+                  || password.length > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
                 throw new InvalidDataException(401, "Invalid password length");
             }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONServer.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/JSONServer.java
@@ -69,7 +69,7 @@ public class JSONServer implements IServerAPI {
     protocols.add(new Protocol(""));
     draftOcppOnly = new Draft_6455(Collections.emptyList(), protocols);
 
-    if(configuration.getParameter("HTTP_HEALTH_CHECK_ENABLED", true)) {
+    if(configuration.getParameter(JSONConfiguration.HTTP_HEALTH_CHECK_ENABLED, true)) {
       logger.info("JSONServer 1.6 with HttpHealthCheckDraft");
       this.listener = new WebSocketListener(sessionFactory, configuration, draftOcppOnly, new Draft_HttpHealthCheck());
     } else {

--- a/ocpp-v2/src/main/java/eu/chargetime/ocpp/MultiProtocolJSONServer.java
+++ b/ocpp-v2/src/main/java/eu/chargetime/ocpp/MultiProtocolJSONServer.java
@@ -73,7 +73,7 @@ public class MultiProtocolJSONServer implements IMultiProtocolServerAPI {
     }
     Draft draft = new Draft_6455(Collections.emptyList(), protocols);
 
-    if (configuration.getParameter("HTTP_HEALTH_CHECK_ENABLED", true)) {
+    if (configuration.getParameter(JSONConfiguration.HTTP_HEALTH_CHECK_ENABLED, true)) {
       logger.info("JSONServer with HttpHealthCheckDraft");
       listener =
           new MultiProtocolWebSocketListener(

--- a/ocpp-v2/src/main/java/eu/chargetime/ocpp/MultiProtocolWebSocketListener.java
+++ b/ocpp-v2/src/main/java/eu/chargetime/ocpp/MultiProtocolWebSocketListener.java
@@ -186,13 +186,13 @@ public class MultiProtocolWebSocketListener implements Listener {
               }
               if (protocolVersion == null || protocolVersion == ProtocolVersion.OCPP1_6) {
                 if (password == null
-                    || password.length < OCPPJ_CP_MIN_PASSWORD_LENGTH
-                    || password.length > OCPPJ_CP_MAX_PASSWORD_LENGTH)
+                    || password.length < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
+                    || password.length > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
                   throw new InvalidDataException(401, "Invalid password length");
               } else {
                 if (password == null
-                    || password.length < OCPP2J_CP_MIN_PASSWORD_LENGTH
-                    || password.length > OCPP2J_CP_MAX_PASSWORD_LENGTH)
+                    || password.length < configuration.getParameter(JSONConfiguration.OCPP2J_CP_MIN_PASSWORD_LENGTH, OCPP2J_CP_MIN_PASSWORD_LENGTH)
+                    || password.length > configuration.getParameter(JSONConfiguration.OCPP2J_CP_MAX_PASSWORD_LENGTH, OCPP2J_CP_MAX_PASSWORD_LENGTH))
                   throw new InvalidDataException(401, "Invalid password length");
               }
             }


### PR DESCRIPTION
This change allows the configuration of the password length with entries in JSONConfiguration.

The password length should be 20 for OCPP 1.6 and 40 for OCPP 2.0. The length of the password should be configurable for cases with longer passwords.