### PR TITLE
Cleanup after sending to avoid memory leak

### DIFF
--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ISession.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ISession.java
@@ -40,6 +40,8 @@ public interface ISession {
 
   String storeRequest(Request payload);
 
+  void removeRequest(String ticket);
+
   void sendRequest(String action, Request payload, String uuid);
 
   boolean completePendingPromise(String id, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException;

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Queue.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Queue.java
@@ -89,6 +89,16 @@ public class Queue {
     return Optional.empty();
   }
 
+  /**
+   * Remove a stored {@link Request} using a unique identifier.
+   * If no request is found for the identifier this method has no effect.
+   *
+   * @param ticket unique identifier returned when {@link Request} was initially stored.
+   */
+  public void removeRequest(String ticket) {
+    requestQueue.remove(ticket);
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("requestQueue", requestQueue).toString();

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java
@@ -115,6 +115,16 @@ public class Session implements ISession {
   }
 
   /**
+   * Remove a stored {@link Request} using a unique identifier.
+   * If no request is found for the identifier this method has no effect.
+   *
+   * @param ticket unique identifier returned when {@link Request} was initially stored.
+   */
+  public void removeRequest(String ticket) {
+    queue.removeRequest(ticket);
+  }
+
+  /**
    * Send a {@link Confirmation} to a {@link Request}
    *
    * @param uniqueId the unique identification the receiver expects.

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ClientTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ClientTest.java
@@ -26,22 +26,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
-
 import eu.chargetime.ocpp.*;
 import eu.chargetime.ocpp.feature.Feature;
 import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
 import eu.chargetime.ocpp.model.TestConfirmation;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientTest {
@@ -63,8 +70,10 @@ public class ClientTest {
         .when(session)
         .open(any(), any());
 
+    when(promiseRepository.createPromise(any())).then(invocation -> new CompletableFuture<Confirmation>());
     when(featureRepository.findFeature(any())).thenReturn(Optional.of(feature));
     when(session.getFeatureRepository()).thenReturn(featureRepository);
+    when(session.storeRequest(any())).then(invocation -> UUID.randomUUID().toString());
     client = new Client(session, promiseRepository);
   }
 
@@ -163,5 +172,69 @@ public class ClientTest {
 
     // Then
     verify(request, times(1)).validate();
+  }
+
+  @Test
+  public void send_aMessage_promiseCompletes() throws Exception {
+    // Given
+    CompletableFuture<Confirmation> internalFuture = new CompletableFuture<>();
+    when(promiseRepository.createPromise(any())).thenReturn(internalFuture);
+
+    // When
+    CompletableFuture<Confirmation> returnedFuture = client.send(request);
+    TestConfirmation confirmation = new TestConfirmation();
+    internalFuture.complete(confirmation);
+
+    // Then
+    assertThat(returnedFuture, is(internalFuture));
+    assertThat(returnedFuture.isDone(), is(true));
+    assertThat(returnedFuture.get(), is(confirmation));
+    verify(session, times(1)).removeRequest(any());
+    verify(promiseRepository, times(1)).removePromise(any());
+  }
+
+  @Test
+  public void send_aMessage_promiseCompletesExceptionally() throws Exception {
+    // Given
+    CompletableFuture<Confirmation> internalFuture = new CompletableFuture<>();
+    when(promiseRepository.createPromise(any())).thenReturn(internalFuture);
+
+    // When
+    CompletableFuture<Confirmation> returnedFuture = client.send(request);
+    internalFuture.completeExceptionally(new IllegalStateException());
+
+    // Then
+    assertThat(returnedFuture, is(internalFuture));
+    assertThat(returnedFuture.isDone(), is(true));
+    assertThat(returnedFuture.isCompletedExceptionally(), is(true));
+    ExecutionException executionException = assertThrows(ExecutionException.class, returnedFuture::get);
+    assertThat(executionException.getCause().getClass(), is(equalTo(IllegalStateException.class)));
+    verify(session, times(1)).removeRequest(any());
+    verify(promiseRepository, times(1)).removePromise(any());
+  }
+
+  @Test
+  public void send_aMessage_promiseCompletesWithTimeout() throws Exception {
+    // Given
+    CompletableFuture<Confirmation> internalFuture = new CompletableFuture<>();
+    when(promiseRepository.createPromise(any())).thenReturn(internalFuture);
+
+    // When
+    CompletableFuture<Confirmation> returnedFuture = client.send(request);
+    // If the client uses at least Java 9, it could use CompletableFuture::orTimeout(..) ..
+    returnedFuture.orTimeout(50, TimeUnit.MILLISECONDS);
+    assertThat(returnedFuture.isDone(), is(false));
+    Thread.sleep(100);
+    // .. alternatively, it can be implemented manually
+//    returnedFuture.completeExceptionally(new TimeoutException());
+
+    // Then
+    assertThat(returnedFuture, is(internalFuture));
+    assertThat(returnedFuture.isDone(), is(true));
+    assertThat(returnedFuture.isCompletedExceptionally(), is(true));
+    ExecutionException executionException = assertThrows(ExecutionException.class, returnedFuture::get);
+    assertThat(executionException.getCause().getClass(), is(equalTo(TimeoutException.class)));
+    verify(session, times(1)).removeRequest(any());
+    verify(promiseRepository, times(1)).removePromise(any());
   }
 }

--- a/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ServerTest.java
+++ b/ocpp-common/src/test/java/eu/chargetime/ocpp/test/ServerTest.java
@@ -1,18 +1,29 @@
 package eu.chargetime.ocpp.test;
 
-import static org.mockito.Mockito.*;
-
 import eu.chargetime.ocpp.*;
 import eu.chargetime.ocpp.feature.Feature;
+import eu.chargetime.ocpp.model.Confirmation;
 import eu.chargetime.ocpp.model.Request;
 import eu.chargetime.ocpp.model.SessionInformation;
-import java.util.Optional;
-import java.util.UUID;
+import eu.chargetime.ocpp.model.TestConfirmation;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.*;
 
 /*
    ChargeTime.eu - Java-OCA-OCPP
@@ -58,7 +69,7 @@ public class ServerTest {
   @Mock private Request request;
   @Mock private SessionInformation information;
   @Mock private IFeatureRepository featureRepository;
-  @Mock private IPromiseRepository promiseRepository;
+  @Mock IPromiseRepository promiseRepository;
 
   @Before
   public void setup() {
@@ -75,8 +86,10 @@ public class ServerTest {
         .when(serverEvents)
         .newSession(any(), any());
 
+    when(promiseRepository.createPromise(any())).then(invocation -> new CompletableFuture<Confirmation>());
     when(featureRepository.findFeature(any())).thenReturn(Optional.of(feature));
     when(session.getFeatureRepository()).thenReturn(featureRepository);
+    when(session.storeRequest(any())).thenAnswer(invocation -> UUID.randomUUID().toString());
     server = new Server(listener, promiseRepository);
   }
 
@@ -142,5 +155,75 @@ public class ServerTest {
 
     // Then
     verify(request, times(1)).validate();
+  }
+
+  @Test
+  public void send_aMessage_promiseCompletes() throws Exception {
+    // Given
+    server.open(LOCALHOST, PORT, serverEvents);
+    listenerEvents.newSession(session, information);
+    CompletableFuture<Confirmation> internalFuture = new CompletableFuture<>();
+    when(promiseRepository.createPromise(any())).thenReturn(internalFuture);
+
+    // When
+    CompletableFuture<Confirmation> returnedFuture = server.send(sessionIndex, request);
+    TestConfirmation confirmation = new TestConfirmation();
+    internalFuture.complete(confirmation);
+
+    // Then
+    assertThat(returnedFuture, is(internalFuture));
+    assertThat(returnedFuture.isDone(), is(true));
+    assertThat(returnedFuture.get(), is(confirmation));
+    verify(session, times(1)).removeRequest(any());
+    verify(promiseRepository, times(1)).removePromise(any());
+  }
+
+  @Test
+  public void send_aMessage_promiseCompletesExceptionally() throws Exception {
+    // Given
+    server.open(LOCALHOST, PORT, serverEvents);
+    listenerEvents.newSession(session, information);
+    CompletableFuture<Confirmation> internalFuture = new CompletableFuture<>();
+    when(promiseRepository.createPromise(any())).thenReturn(internalFuture);
+
+    // When
+    CompletableFuture<Confirmation> returnedFuture = server.send(sessionIndex, request);
+    internalFuture.completeExceptionally(new IllegalStateException());
+
+    // Then
+    assertThat(returnedFuture, is(internalFuture));
+    assertThat(returnedFuture.isDone(), is(true));
+    assertThat(returnedFuture.isCompletedExceptionally(), is(true));
+    ExecutionException executionException = assertThrows(ExecutionException.class, returnedFuture::get);
+    assertThat(executionException.getCause().getClass(), is(equalTo(IllegalStateException.class)));
+    verify(session, times(1)).removeRequest(any());
+    verify(promiseRepository, times(1)).removePromise(any());
+  }
+
+  @Test
+  public void send_aMessage_promiseCompletesWithTimeout() throws Exception {
+    // Given
+    server.open(LOCALHOST, PORT, serverEvents);
+    listenerEvents.newSession(session, information);
+    CompletableFuture<Confirmation> internalFuture = new CompletableFuture<>();
+    when(promiseRepository.createPromise(any())).thenReturn(internalFuture);
+
+    // When
+    CompletableFuture<Confirmation> returnedFuture = server.send(sessionIndex, request);
+    // If the client uses at least Java 9, it could use CompletableFuture::orTimeout(..).
+    returnedFuture.orTimeout(50, TimeUnit.MILLISECONDS);
+    assertThat(returnedFuture.isDone(), is(false));
+    Thread.sleep(100);
+    // .. alternatively, it can be implemented manually
+//    returnedFuture.completeExceptionally(new TimeoutException());
+
+    // Then
+    assertThat(returnedFuture, is(internalFuture));
+    assertThat(returnedFuture.isDone(), is(true));
+    assertThat(returnedFuture.isCompletedExceptionally(), is(true));
+    ExecutionException executionException = assertThrows(ExecutionException.class, returnedFuture::get);
+    assertThat(executionException.getCause().getClass(), is(equalTo(TimeoutException.class)));
+    verify(session, times(1)).removeRequest(any());
+    verify(promiseRepository, times(1)).removePromise(any());
   }
 }

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/TimeoutSessionDecorator.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/TimeoutSessionDecorator.java
@@ -93,6 +93,11 @@ public class TimeoutSessionDecorator implements ISession {
   }
 
   @Override
+  public void removeRequest(String ticket) {
+    this.session.removeRequest(ticket);
+  }
+
+  @Override
   public boolean completePendingPromise(String id, Confirmation confirmation) throws UnsupportedFeatureException, OccurenceConstraintException {
     return this.session.completePendingPromise(id, confirmation);
   }


### PR DESCRIPTION
#### There is a potential memory leak after sending a request using Server#send() or Client#send():

When a request is sent, the `Request` object and the associated `CompletableFuture` are stored in maps (in class `Queue` and `PromiseRepository` respectively).
While both are cleanup up when a successful confirmation is received from the communication partner, this is not the case if either an error or no confirmation at all is received:
- If an error is received only the `PromiseRepository` but not the `Queue` is cleanup up.
- If no message is received there is no way to clean up any of the maps.

#### This pull request tries to solve these problems:

`Queue` and `PromiseRepository` are cleanup up whenever the `CompletableFuture` resolves, whether successful or not.

This gives users of the `send()` method the chance to add a timeout to the returned `CompletableFuture`, e.g. by using:
`server.send(sessionIndex, request).orTimeout(10, TimeUnit.SECONDS)` 
(refer to ServerTest#send_aMessage_promiseCompletesWithTimeout())

As the returned `CompletableFuture` is identical to one inside `send()`, after a timeout occurs, the future is completed with a `TimeoutException` and both maps will be cleanup up.

I'm very interested in your feedback!

By the way, thank you very much for your work on this nice and elegant library!

Best regards, 
Martin