### PR TITLE
Revert commits breaking API and binary OCPP 1.6 passwords

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
@@ -49,10 +49,8 @@ public class JSONConfiguration {
 
   private JSONConfiguration() {}
 
-  private static final JSONConfiguration instance = new JSONConfiguration();
-
   public static JSONConfiguration get() {
-    return instance;
+    return new JSONConfiguration();
   }
 
   public <T> JSONConfiguration setParameter(String name, T value) {

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
@@ -51,7 +51,7 @@ public class WebSocketListener implements Listener {
   private static final int TIMEOUT_IN_MILLIS = 10000;
 
   private static final int OCPPJ_CP_MIN_PASSWORD_LENGTH = 16;
-  private static final int OCPPJ_CP_MAX_PASSWORD_LENGTH = 40;
+  private static final int OCPPJ_CP_MAX_PASSWORD_LENGTH = 20;
 
   private static final String HTTP_HEADER_PROXIED_ADDRESS = "X-Forwarded-For";
 
@@ -146,7 +146,7 @@ public class WebSocketListener implements Listener {
                     .build();
 
             String username = null;
-            String password = null;
+            byte[] password = null;
             if (clientHandshake.hasFieldValue("Authorization")) {
               String authorization = clientHandshake.getFieldValue("Authorization");
               if (authorization != null && authorization.toLowerCase().startsWith("basic")) {
@@ -159,15 +159,15 @@ public class WebSocketListener implements Listener {
                     username =
                         new String(Arrays.copyOfRange(credDecoded, 0, i), StandardCharsets.UTF_8);
                     if (i + 1 < credDecoded.length) {
-                      password = new String(Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length));
+                      password = Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length);
                     }
                     break;
                   }
                 }
               }
               if (password == null
-                  || password.length() < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
-                  || password.length() > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
+                  || password.length < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
+                  || password.length > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
                 throw new InvalidDataException(401, "Invalid password length");
             }
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ListenerEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ListenerEvents.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp;
 import eu.chargetime.ocpp.model.SessionInformation;
 
 public interface ListenerEvents {
-  void authenticateSession(SessionInformation information, String username, String password)
+  void authenticateSession(SessionInformation information, String username, byte[] password)
       throws AuthenticationException;
 
   void newSession(ISession session, SessionInformation information);

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
@@ -81,7 +81,7 @@ public class Server {
 
           @Override
           public void authenticateSession(
-              SessionInformation information, String username, String password)
+              SessionInformation information, String username, byte[] password)
               throws AuthenticationException {
             serverEvents.authenticateSession(information, username, password);
           }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ServerEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ServerEvents.java
@@ -29,7 +29,7 @@ import eu.chargetime.ocpp.model.SessionInformation;
 import java.util.UUID;
 
 public interface ServerEvents {
-  void authenticateSession(SessionInformation information, String username, String password) throws AuthenticationException;
+  void authenticateSession(SessionInformation information, String username, byte[] password) throws AuthenticationException;
 
   void newSession(UUID sessionIndex, SessionInformation information);
 

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/DummyHandlers.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/DummyHandlers.java
@@ -203,7 +203,7 @@ public class DummyHandlers {
     return new ServerEvents() {
       @Override
       public void authenticateSession(
-          SessionInformation information, String username, String password) throws AuthenticationException {}
+          SessionInformation information, String username, byte[] password) throws AuthenticationException {}
 
       @Override
       public void newSession(UUID sessionIndex, SessionInformation information) {

--- a/ocpp-v2/src/main/java/eu/chargetime/ocpp/MultiProtocolWebSocketListener.java
+++ b/ocpp-v2/src/main/java/eu/chargetime/ocpp/MultiProtocolWebSocketListener.java
@@ -165,7 +165,7 @@ public class MultiProtocolWebSocketListener implements Listener {
                     .build();
 
             String username = null;
-            String password = null;
+            byte[] password = null;
             if (clientHandshake.hasFieldValue("Authorization")) {
               String authorization = clientHandshake.getFieldValue("Authorization");
               if (authorization != null && authorization.toLowerCase().startsWith("basic")) {
@@ -178,7 +178,7 @@ public class MultiProtocolWebSocketListener implements Listener {
                     username =
                         new String(Arrays.copyOfRange(credDecoded, 0, i), StandardCharsets.UTF_8);
                     if (i + 1 < credDecoded.length) {
-                      password = new String(Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length));
+                      password = Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length);
                     }
                     break;
                   }
@@ -186,13 +186,13 @@ public class MultiProtocolWebSocketListener implements Listener {
               }
               if (protocolVersion == null || protocolVersion == ProtocolVersion.OCPP1_6) {
                 if (password == null
-                    || password.length() < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
-                    || password.length() > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
+                    || password.length < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
+                    || password.length > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
                   throw new InvalidDataException(401, "Invalid password length");
               } else {
                 if (password == null
-                    || password.length() < configuration.getParameter(JSONConfiguration.OCPP2J_CP_MIN_PASSWORD_LENGTH, OCPP2J_CP_MIN_PASSWORD_LENGTH)
-                    || password.length() > configuration.getParameter(JSONConfiguration.OCPP2J_CP_MAX_PASSWORD_LENGTH, OCPP2J_CP_MAX_PASSWORD_LENGTH))
+                    || password.length < configuration.getParameter(JSONConfiguration.OCPP2J_CP_MIN_PASSWORD_LENGTH, OCPP2J_CP_MIN_PASSWORD_LENGTH)
+                    || password.length > configuration.getParameter(JSONConfiguration.OCPP2J_CP_MAX_PASSWORD_LENGTH, OCPP2J_CP_MAX_PASSWORD_LENGTH))
                   throw new InvalidDataException(401, "Invalid password length");
               }
             }

--- a/ocpp-v2_0-test/src/main/java/eu/chargetime/ocpp/test/FakeCentralSystem.java
+++ b/ocpp-v2_0-test/src/main/java/eu/chargetime/ocpp/test/FakeCentralSystem.java
@@ -74,7 +74,7 @@ public class FakeCentralSystem {
           new ServerEvents() {
             @Override
             public void authenticateSession(
-                SessionInformation information, String username, String password) throws AuthenticationException {}
+                SessionInformation information, String username, byte[] password) throws AuthenticationException {}
 
             @Override
             public void newSession(UUID sessionIndex, SessionInformation information) {


### PR DESCRIPTION
These commits were based on a misunderstanding of the OCPP-J 1.6 specification, which clearly states that the password is a byte sequence and not a string. Also, they broke the ServerEvents#authenticateSession() API:

Revert "More password fixes."

This reverts commit fb5d0fb4c9e5cf8e1f14ab97ea5e15422fb441f4.

Revert "Fix password decoding."

This reverts commit cf20205e849a258ee5f4893a1d916ef8091f12d1.

Revert "Recommended by 1.6 spec is a 20 byte (40 chars) key."

This reverts commit f7b92a3d6ae51cce4e6bbdcc25148cb951e986d1.

This commit breaks the API, because the behaviour of the method is changed to return the last configuration instead of the default configuration:

Revert "A single instace, otherwise a static get() method makes no sense."

This reverts commit 953f50b3e7c4b975cae5ebcb74c2bd6e381d5e23.