### PR TITLE
Implement CALLERROR: SecurityError response

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
@@ -49,10 +49,8 @@ public class JSONConfiguration {
 
   private JSONConfiguration() {}
 
-  private static final JSONConfiguration instance = new JSONConfiguration();
-
   public static JSONConfiguration get() {
-    return instance;
+    return new JSONConfiguration();
   }
 
   public <T> JSONConfiguration setParameter(String name, T value) {

--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/WebSocketListener.java
@@ -51,7 +51,7 @@ public class WebSocketListener implements Listener {
   private static final int TIMEOUT_IN_MILLIS = 10000;
 
   private static final int OCPPJ_CP_MIN_PASSWORD_LENGTH = 16;
-  private static final int OCPPJ_CP_MAX_PASSWORD_LENGTH = 40;
+  private static final int OCPPJ_CP_MAX_PASSWORD_LENGTH = 20;
 
   private static final String HTTP_HEADER_PROXIED_ADDRESS = "X-Forwarded-For";
 
@@ -146,7 +146,7 @@ public class WebSocketListener implements Listener {
                     .build();
 
             String username = null;
-            String password = null;
+            byte[] password = null;
             if (clientHandshake.hasFieldValue("Authorization")) {
               String authorization = clientHandshake.getFieldValue("Authorization");
               if (authorization != null && authorization.toLowerCase().startsWith("basic")) {
@@ -159,15 +159,15 @@ public class WebSocketListener implements Listener {
                     username =
                         new String(Arrays.copyOfRange(credDecoded, 0, i), StandardCharsets.UTF_8);
                     if (i + 1 < credDecoded.length) {
-                      password = new String(Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length));
+                      password = Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length);
                     }
                     break;
                   }
                 }
               }
               if (password == null
-                  || password.length() < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
-                  || password.length() > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
+                  || password.length < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
+                  || password.length > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
                 throw new InvalidDataException(401, "Invalid password length");
             }
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ListenerEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ListenerEvents.java
@@ -28,7 +28,7 @@ package eu.chargetime.ocpp;
 import eu.chargetime.ocpp.model.SessionInformation;
 
 public interface ListenerEvents {
-  void authenticateSession(SessionInformation information, String username, String password)
+  void authenticateSession(SessionInformation information, String username, byte[] password)
       throws AuthenticationException;
 
   void newSession(ISession session, SessionInformation information);

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/SecurityErrorException.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/SecurityErrorException.java
@@ -1,0 +1,35 @@
+package eu.chargetime.ocpp;
+
+/*
+ChargeTime.eu - Java-OCA-OCPP
+Copyright (C) 2024 Robert Schlabbach <robert.schlabbach@ubitricity.com>
+
+MIT License
+
+Copyright (C) 2024 Robert Schlabbach
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/** A security issue occurred */
+public class SecurityErrorException extends IllegalStateException {
+  public SecurityErrorException(String s) {
+    super(s);
+  }
+}

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Server.java
@@ -81,7 +81,7 @@ public class Server {
 
           @Override
           public void authenticateSession(
-              SessionInformation information, String username, String password)
+              SessionInformation information, String username, byte[] password)
               throws AuthenticationException {
             serverEvents.authenticateSession(information, username, password);
           }

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ServerEvents.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ServerEvents.java
@@ -29,7 +29,7 @@ import eu.chargetime.ocpp.model.SessionInformation;
 import java.util.UUID;
 
 public interface ServerEvents {
-  void authenticateSession(SessionInformation information, String username, String password) throws AuthenticationException;
+  void authenticateSession(SessionInformation information, String username, byte[] password) throws AuthenticationException;
 
   void newSession(UUID sessionIndex, SessionInformation information);
 

--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java
@@ -228,6 +228,9 @@ public class Session implements ISession {
         } catch (PropertyConstraintException ex) {
           logger.warn(ex.getMessage(), ex);
           communicator.sendCallError(id, action, "TypeConstraintViolation", ex.getMessage());
+        } catch (SecurityErrorException ex) {
+          logger.warn(ex.getMessage(), ex);
+          communicator.sendCallError(id, action, "SecurityError", ex.getMessage());
         } catch (Exception ex) {
           logger.warn(UNABLE_TO_PROCESS, ex);
           communicator.sendCallError(id, action, isLegacyRPC() ? "FormationViolation" :

--- a/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/DummyHandlers.java
+++ b/ocpp-v1_6-test/src/main/java/eu/chargetime/ocpp/test/DummyHandlers.java
@@ -203,7 +203,7 @@ public class DummyHandlers {
     return new ServerEvents() {
       @Override
       public void authenticateSession(
-          SessionInformation information, String username, String password) throws AuthenticationException {}
+          SessionInformation information, String username, byte[] password) throws AuthenticationException {}
 
       @Override
       public void newSession(UUID sessionIndex, SessionInformation information) {

--- a/ocpp-v2/src/main/java/eu/chargetime/ocpp/MultiProtocolWebSocketListener.java
+++ b/ocpp-v2/src/main/java/eu/chargetime/ocpp/MultiProtocolWebSocketListener.java
@@ -165,7 +165,7 @@ public class MultiProtocolWebSocketListener implements Listener {
                     .build();
 
             String username = null;
-            String password = null;
+            byte[] password = null;
             if (clientHandshake.hasFieldValue("Authorization")) {
               String authorization = clientHandshake.getFieldValue("Authorization");
               if (authorization != null && authorization.toLowerCase().startsWith("basic")) {
@@ -178,7 +178,7 @@ public class MultiProtocolWebSocketListener implements Listener {
                     username =
                         new String(Arrays.copyOfRange(credDecoded, 0, i), StandardCharsets.UTF_8);
                     if (i + 1 < credDecoded.length) {
-                      password = new String(Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length));
+                      password = Arrays.copyOfRange(credDecoded, i + 1, credDecoded.length);
                     }
                     break;
                   }
@@ -186,13 +186,13 @@ public class MultiProtocolWebSocketListener implements Listener {
               }
               if (protocolVersion == null || protocolVersion == ProtocolVersion.OCPP1_6) {
                 if (password == null
-                    || password.length() < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
-                    || password.length() > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
+                    || password.length < configuration.getParameter(JSONConfiguration.OCPPJ_CP_MIN_PASSWORD_LENGTH, OCPPJ_CP_MIN_PASSWORD_LENGTH)
+                    || password.length > configuration.getParameter(JSONConfiguration.OCPPJ_CP_MAX_PASSWORD_LENGTH, OCPPJ_CP_MAX_PASSWORD_LENGTH))
                   throw new InvalidDataException(401, "Invalid password length");
               } else {
                 if (password == null
-                    || password.length() < configuration.getParameter(JSONConfiguration.OCPP2J_CP_MIN_PASSWORD_LENGTH, OCPP2J_CP_MIN_PASSWORD_LENGTH)
-                    || password.length() > configuration.getParameter(JSONConfiguration.OCPP2J_CP_MAX_PASSWORD_LENGTH, OCPP2J_CP_MAX_PASSWORD_LENGTH))
+                    || password.length < configuration.getParameter(JSONConfiguration.OCPP2J_CP_MIN_PASSWORD_LENGTH, OCPP2J_CP_MIN_PASSWORD_LENGTH)
+                    || password.length > configuration.getParameter(JSONConfiguration.OCPP2J_CP_MAX_PASSWORD_LENGTH, OCPP2J_CP_MAX_PASSWORD_LENGTH))
                   throw new InvalidDataException(401, "Invalid password length");
               }
             }

--- a/ocpp-v2_0-test/src/main/java/eu/chargetime/ocpp/test/FakeCentralSystem.java
+++ b/ocpp-v2_0-test/src/main/java/eu/chargetime/ocpp/test/FakeCentralSystem.java
@@ -74,7 +74,7 @@ public class FakeCentralSystem {
           new ServerEvents() {
             @Override
             public void authenticateSession(
-                SessionInformation information, String username, String password) throws AuthenticationException {}
+                SessionInformation information, String username, byte[] password) throws AuthenticationException {}
 
             @Override
             public void newSession(UUID sessionIndex, SessionInformation information) {


### PR DESCRIPTION
OCPP 2.0.1 requires a CALLERROR: SecurityError response from the CSMS if the Charging Station sends a request before having been accepted.
    
Implement a mechanism to send this response, by throwing the newly added SecurityErrorException in the message handler of a disallowed request.
    
This fixes issue #350.