### PR TITLE
Allow 0 for retries and retryInterval for UpdateFirmware and GetDiagnostics

### DIFF
--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/GetDiagnosticsRequest.java
@@ -26,6 +26,7 @@ package eu.chargetime.ocpp.model.firmware;
   SOFTWARE.
 */
 
+import eu.chargetime.ocpp.PropertyConstraintException;
 import eu.chargetime.ocpp.model.RequestWithId;
 import eu.chargetime.ocpp.utilities.MoreObjects;
 import java.time.ZonedDateTime;
@@ -107,6 +108,10 @@ public class GetDiagnosticsRequest extends RequestWithId {
    */
   @XmlElement
   public void setRetries(Integer retries) {
+    if (retries < 0) {
+      throw new PropertyConstraintException(retries, "retries must be >= 0");
+    }
+
     this.retries = retries;
   }
 
@@ -128,6 +133,10 @@ public class GetDiagnosticsRequest extends RequestWithId {
    */
   @XmlElement
   public void setRetryInterval(Integer retryInterval) {
+    if (retryInterval < 0) {
+      throw new PropertyConstraintException(retryInterval, "retryInterval must be >= 0");
+    }
+
     this.retryInterval = retryInterval;
   }
 

--- a/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareRequest.java
+++ b/ocpp-v1_6/src/main/java/eu/chargetime/ocpp/model/firmware/UpdateFirmwareRequest.java
@@ -112,8 +112,8 @@ public class UpdateFirmwareRequest extends RequestWithId {
    */
   @XmlElement
   public void setRetries(int retries) {
-    if (retries <= 0) {
-      throw new PropertyConstraintException(retries, "retries must be > 0");
+    if (retries < 0) {
+      throw new PropertyConstraintException(retries, "retries must be >= 0");
     }
 
     this.retries = retries;
@@ -157,8 +157,8 @@ public class UpdateFirmwareRequest extends RequestWithId {
    */
   @XmlElement
   public void setRetryInterval(int retryInterval) {
-    if (retryInterval <= 0) {
-      throw new PropertyConstraintException(retryInterval, "retryInterval must be > 0");
+    if (retryInterval < 0) {
+      throw new PropertyConstraintException(retryInterval, "retryInterval must be >= 0");
     }
 
     this.retryInterval = retryInterval;

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/firmware/test/GetDiagnosticsRequestTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/firmware/test/GetDiagnosticsRequestTest.java
@@ -25,14 +25,22 @@ package eu.chargetime.ocpp.model.firmware.test;
    SOFTWARE.
 */
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import eu.chargetime.ocpp.PropertyConstraintException;
 import eu.chargetime.ocpp.model.firmware.GetDiagnosticsRequest;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class GetDiagnosticsRequestTest {
+
+  @Rule
+  public ExpectedException thrownException = ExpectedException.none();
 
   private GetDiagnosticsRequest request;
 
@@ -61,5 +69,55 @@ public class GetDiagnosticsRequestTest {
 
     // Then
     assertThat(result, is(true));
+  }
+
+  @Test
+  public void setRetries_asPositive_isAccepted() {
+    request.setRetries(42);
+
+    assertThat(request.getRetries(), equalTo(42));
+  }
+
+  @Test
+  public void setRetries_asZero_isAccepted() {
+    request.setRetries(0);
+
+    assertThat(request.getRetries(), equalTo(0));
+  }
+
+  @Test
+  public void setRetries_asNegative_throwsPropertyConstraintException() {
+    int retries = -42;
+    thrownException.expect(instanceOf(PropertyConstraintException.class));
+    thrownException.expectMessage(
+        equalTo("Validation failed: [retries must be >= 0]. Current Value: [" + retries + "]"));
+
+    request.setRetries(retries);
+  }
+
+  @Test
+  public void setRetryInterval_asPositive_isAccepted() {
+    request.setRetryInterval(42);
+
+    assertThat(request.getRetryInterval(), equalTo(42));
+  }
+
+  @Test
+  public void setRetryInterval_asZero_isAccepted() {
+    request.setRetryInterval(0);
+
+    assertThat(request.getRetryInterval(), equalTo(0));
+  }
+
+  @Test
+  public void setRetryInterval_asNegative_throwsPropertyConstraintException() {
+    int retryInterval = -42;
+    thrownException.expect(instanceOf(PropertyConstraintException.class));
+    thrownException.expectMessage(
+        equalTo("Validation failed: [retryInterval must be >= 0]. Current Value: ["
+            + retryInterval
+            + "]"));
+
+    request.setRetryInterval(retryInterval);
   }
 }

--- a/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/firmware/test/UpdateFirmwareRequestTest.java
+++ b/ocpp-v1_6/src/test/java/eu/chargetime/ocpp/model/firmware/test/UpdateFirmwareRequestTest.java
@@ -89,19 +89,11 @@ public class UpdateFirmwareRequestTest {
 
   @Test
   public void setRetries_asNegative_throwsPropertyConstraintException() {
-    testInvalidRetries(-42);
-  }
-
-  @Test
-  public void setRetries_asZero_throwsPropertyConstraintException() {
-    testInvalidRetries(0);
-  }
-
-  private void testInvalidRetries(int retryInvalidRetries) {
+    int retries = -42;
     defineThrownException(
-        "Validation failed: [retries must be > 0]. Current Value: [" + retryInvalidRetries + "]");
+        "Validation failed: [retries must be >= 0]. Current Value: [" + retries + "]");
 
-    request.setRetries(retryInvalidRetries);
+    request.setRetries(retries);
   }
 
   private void defineThrownException(String expectedExceptionMessage) {
@@ -117,22 +109,21 @@ public class UpdateFirmwareRequestTest {
   }
 
   @Test
-  public void setRetryInterval_asNegative_throwsPropertyConstraintException() {
-    testInvalidRetryInterval(-42);
+  public void setRetries_asZero_isAccepted() {
+    request.setRetries(0);
+
+    assertThat(request.getRetries(), equalTo(0));
   }
 
   @Test
-  public void setRetryInterval_asZero_throwsPropertyConstraintException() {
-    testInvalidRetryInterval(0);
-  }
-
-  private void testInvalidRetryInterval(int invalidRetryValue) {
+  public void setRetryInterval_asNegative_throwsPropertyConstraintException() {
+    int retryInterval = -42;
     defineThrownException(
-        "Validation failed: [retryInterval must be > 0]. Current Value: ["
-            + invalidRetryValue
+        "Validation failed: [retryInterval must be >= 0]. Current Value: ["
+            + retryInterval
             + "]");
 
-    request.setRetryInterval(invalidRetryValue);
+    request.setRetryInterval(retryInterval);
   }
 
   @Test
@@ -140,5 +131,12 @@ public class UpdateFirmwareRequestTest {
     request.setRetryInterval(42);
 
     assertThat(request.getRetryInterval(), equalTo(42));
+  }
+
+  @Test
+  public void setRetryInterval_asZero_isAccepted() {
+    request.setRetryInterval(0);
+
+    assertThat(request.getRetryInterval(), equalTo(0));
   }
 }


### PR DESCRIPTION
## Description
This PR allows a value of 0 for retries and retryInterval, which is in UpdateFirmware and GetDiagnostics. Based on the errata, 0 should be a valid value.

Fixes https://github.com/ChargeTimeEU/Java-OCA-OCPP/issues/362.