### PR TITLE
Suppress "unchecked or unsafe operations" warning in JSONConfiguration

### DIFF
--- a/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
+++ b/OCPP-J/src/main/java/eu/chargetime/ocpp/JSONConfiguration.java
@@ -58,11 +58,13 @@ public class JSONConfiguration {
     return this;
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T getParameter(String name) {
     //noinspection unchecked
     return (T) parameters.get(name);
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T getParameter(String name, T defaultValue) {
     //noinspection unchecked
     T value = (T) parameters.get(name);


### PR DESCRIPTION
On every build, xmlint warned about "unchecked or unsafe operations" in the JSONConfiguration class, but fixing that would be an API-breaking change to the OCPP library.

Suppress the warnings, since they cannot be fixed for now.