### PR TITLE
Downgrade logback dependencies to version 1.3.16

### DIFF
--- a/OCPP-J/pom.xml
+++ b/OCPP-J/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.21</version>
+            <version>1.3.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ocpp-common/pom.xml
+++ b/ocpp-common/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.21</version>
+            <version>1.3.16</version>
             <scope>test</scope>
         </dependency>
 

--- a/ocpp-v1_6-test/pom.xml
+++ b/ocpp-v1_6-test/pom.xml
@@ -77,13 +77,13 @@
 		<dependency>
 		    <groupId>ch.qos.logback</groupId>
 		    <artifactId>logback-core</artifactId>
-		    <version>1.5.21</version>
+		    <version>1.3.16</version>
             <scope>test</scope>
 		</dependency>
 		<dependency>
 		    <groupId>ch.qos.logback</groupId>
 		    <artifactId>logback-classic</artifactId>
-		    <version>1.5.21</version>
+		    <version>1.3.16</version>
 		    <scope>test</scope>
 		</dependency>
 		<dependency>

--- a/ocpp-v1_6/pom.xml
+++ b/ocpp-v1_6/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.21</version>
+            <version>1.3.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ocpp-v2-test/pom.xml
+++ b/ocpp-v2-test/pom.xml
@@ -103,13 +103,13 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.21</version>
+            <version>1.3.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.21</version>
+            <version>1.3.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ocpp-v2/pom.xml
+++ b/ocpp-v2/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.21</version>
+            <version>1.3.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ocpp-v2_0-test/pom.xml
+++ b/ocpp-v2_0-test/pom.xml
@@ -78,13 +78,13 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.21</version>
+            <version>1.3.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.21</version>
+            <version>1.3.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The logback-classic and logback-core packages 1.4+ do not support Java 8 anymore.

Downgrade the dependencies to the latest 1.3.x release to remain Java 8 compatible.