### PR TITLE
Update gradle dependencies after dependabot updates

### DIFF
--- a/OCPP-J/build.gradle
+++ b/OCPP-J/build.gradle
@@ -4,11 +4,11 @@
 
 dependencies {
     compile project(':common')
-    compile 'com.google.code.gson:gson:2.8.9'
+    compile 'com.google.code.gson:gson:2.13.2'
     compile 'org.java-websocket:Java-WebSocket:1.6.0'
     testCompile 'junit:junit:4.13.2'
     testCompile 'org.mockito:mockito-core:4.11.0'
-    testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.hamcrest:hamcrest-core:3.0'
 }
 
 task javadocJar(type: Jar) {

--- a/ocpp-common/build.gradle
+++ b/ocpp-common/build.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.25'
-    compile 'ch.qos.logback:logback-classic:1.2.3'
+    compile 'org.slf4j:slf4j-api:2.0.17'
+    compile 'ch.qos.logback:logback-classic:1.3.16'
     compile group: 'javax.xml.soap', name: 'javax.xml.soap-api', version: '1.4.0'
     compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.1'
 

--- a/ocpp-v1_6-test/build.gradle
+++ b/ocpp-v1_6-test/build.gradle
@@ -9,13 +9,13 @@ plugins {
 dependencies {
     compile project(':common')
     compile project(':v1_6')
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
-    testCompile 'org.hamcrest:hamcrest-core:1.3'
-    testCompile 'ch.qos.logback:logback-core:1.1.2'
-    testCompile 'ch.qos.logback:logback-classic:1.1.2'
-    testCompile 'org.slf4j:jul-to-slf4j:1.7.10'
+    testCompile 'org.hamcrest:hamcrest-core:3.0'
+    testCompile 'ch.qos.logback:logback-core:1.3.16'
+    testCompile 'ch.qos.logback:logback-classic:1.3.16'
+    testCompile 'org.slf4j:jul-to-slf4j:2.0.17'
 }
 
 description = 'Java-OCA-OCPP v1.6 - Integration test'

--- a/ocpp-v1_6/build.gradle
+++ b/ocpp-v1_6/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     testCompile 'junit:junit:4.13.2'
     testCompile 'org.mockito:mockito-core:4.11.0'
-    testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.hamcrest:hamcrest-core:3.0'
 }
 
 task javadocJar(type: Jar) {

--- a/ocpp-v2-test/build.gradle
+++ b/ocpp-v2-test/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile 'com.google.code.findbugs:jsr305:3.0.1'
     testCompile 'junit:junit:4.13.2'
     testCompile 'org.mockito:mockito-core:4.11.0'
-    testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.hamcrest:hamcrest-core:3.0'
 }
 
 description = 'Java-OCA-OCPP v2 - Integration test'

--- a/ocpp-v2/build.gradle
+++ b/ocpp-v2/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile 'org.java-websocket:Java-WebSocket:1.6.0'
     testCompile 'junit:junit:4.13.2'
     testCompile 'org.mockito:mockito-core:4.11.0'
-    testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.hamcrest:hamcrest-core:3.0'
 }
 
 task javadocJar(type: Jar) {

--- a/ocpp-v2_0-test/build.gradle
+++ b/ocpp-v2_0-test/build.gradle
@@ -9,13 +9,13 @@ plugins {
 dependencies {
     compile project(':common')
     compile project(':v2_0')
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.11'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
-    testCompile 'org.hamcrest:hamcrest-core:1.3'
-    testCompile 'ch.qos.logback:logback-core:1.1.2'
-    testCompile 'ch.qos.logback:logback-classic:1.1.2'
-    testCompile 'org.slf4j:jul-to-slf4j:1.7.10'
+    testCompile 'org.hamcrest:hamcrest-core:3.0'
+    testCompile 'ch.qos.logback:logback-core:1.3.16'
+    testCompile 'ch.qos.logback:logback-classic:1.3.16'
+    testCompile 'org.slf4j:jul-to-slf4j:2.0.17'
 }
 
 description = 'Java-OCA-OCPP v2.0 - Integration test'

--- a/ocpp-v2_0/build.gradle
+++ b/ocpp-v2_0/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile 'org.java-websocket:Java-WebSocket:1.6.0'
     testCompile 'junit:junit:4.13.2'
     testCompile 'org.mockito:mockito-core:4.11.0'
-    testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.hamcrest:hamcrest-core:3.0'
 }
 
 task javadocJar(type: Jar) {


### PR DESCRIPTION
The merged github dependabot PRs only updated the maven pom.xml files.

Update the gradle build files to the same dependency versions.