### PR TITLE
Add Gradle to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot was only creating PRs to update the Maven pom.xml files with new dependency versions, while the Gradle build.gradle files had to be updated manually, which was often missed, leaving the Gradle build out of sync.

Add gradle to the dependabot configuration so that it creates PRs to update the Gradle build.gradle files as well.