### PR TITLE
make ConfirmationHandler public

### DIFF
--- a/ocpp-common/src/main/java/eu/chargetime/ocpp/ConfirmationHandler.java
+++ b/ocpp-common/src/main/java/eu/chargetime/ocpp/ConfirmationHandler.java
@@ -29,7 +29,7 @@ package eu.chargetime.ocpp;
 import eu.chargetime.ocpp.model.Confirmation;
 import java.util.function.BiConsumer;
 
-class ConfirmationHandler implements BiConsumer<Confirmation, Throwable> {
+public class ConfirmationHandler implements BiConsumer<Confirmation, Throwable> {
 
   private String id;
   private String action;


### PR DESCRIPTION
this allows implementations to reuse CommunicatorEventHandler following the current package-internal use of `new ConfirmationHandler` in the style of:

https://github.com/ChargeTimeEU/Java-OCA-OCPP/blob/95080cfc0036932a2463ed0ccfd269b6698665a5/ocpp-common/src/main/java/eu/chargetime/ocpp/Session.java#L239